### PR TITLE
chore: Add keystore plugin in distribution

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/pom.xml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/pom.xml
@@ -81,6 +81,14 @@
 			<type>zip</type>
 			<scope>runtime</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>io.gravitee.am.certificate</groupId>
+			<artifactId>gravitee-am-certificate-javakeystore</artifactId>
+			<version>${project.version}</version>
+			<type>zip</type>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -118,6 +126,14 @@
 								<artifactItem>
 									<groupId>io.gravitee.am.identityprovider</groupId>
 									<artifactId>gravitee-am-identityprovider-ldap</artifactId>
+									<version>${project.version}</version>
+									<type>zip</type>
+								</artifactItem>
+
+								<!-- Certificates -->
+								<artifactItem>
+									<groupId>io.gravitee.am.certificate</groupId>
+									<artifactId>gravitee-am-certificate-javakeystore</artifactId>
 									<version>${project.version}</version>
 									<type>zip</type>
 								</artifactItem>


### PR DESCRIPTION
Closes gravitee-io/graviteeio-access-management#99