### PR TITLE
fix(oidc): hybrid flow response type code+token should not have an id…

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/src/main/java/io/gravitee/am/gateway/handler/oauth2/request/OAuth2Request.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/src/main/java/io/gravitee/am/gateway/handler/oauth2/request/OAuth2Request.java
@@ -78,6 +78,10 @@ public class OAuth2Request extends BaseRequest {
     }
 
     public boolean shouldGenerateIDToken() {
+        if (getResponseType() != null && ResponseType.CODE_TOKEN.equals(getResponseType())) {
+            return false;
+        }
+
         if (getResponseType() != null
                 && (ResponseType.CODE_ID_TOKEN_TOKEN.equals(getResponseType()) || ResponseType.ID_TOKEN_TOKEN.equals(getResponseType()))) {
             return true;


### PR DESCRIPTION
…_token in response even with scope openid

fixes #439