### PR TITLE
exposing port 8093 instead of 8092

### DIFF
--- a/docker/management-api/Dockerfile
+++ b/docker/management-api/Dockerfile
@@ -36,6 +36,6 @@ USER 1000
 
 WORKDIR ${GRAVITEEAM_HOME}
 
-EXPOSE 8092
+EXPOSE 8093
 VOLUME ["/opt/graviteeio-am-management-api/logs"]
 CMD ["./bin/gravitee"]

--- a/docker/management-api/Dockerfile-nightly
+++ b/docker/management-api/Dockerfile-nightly
@@ -36,6 +36,6 @@ USER 1000
 
 WORKDIR ${GRAVITEEAM_HOME}
 
-EXPOSE 8092
+EXPOSE 8093
 VOLUME ["/opt/graviteeio-am-management-api/logs"]
 CMD ["./bin/gravitee"]


### PR DESCRIPTION
Exposed port in Dockerfiles for management-api are wrong.