### PR TITLE
redirect_uris management + additional behaviour

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,7 @@ postman: ## Run postman non regression test (require newman npm module)
 	@newman run postman/collections/graviteeio-am-openid-core-collection.json -e postman/environment/dev.json --ignore-redirects --insecure --bail
 	@newman run postman/collections/graviteeio-am-openid-dcr-collection.json -e postman/environment/dev.json --ignore-redirects --insecure --bail
 	@newman run postman/collections/graviteeio-am-scim-collection.json -e postman/environment/dev.json --ignore-redirects --insecure --bail
+	@newman run postman/collections/graviteeio-am-client-management-collection.json -e postman/environment/dev.json --ignore-redirects --insecure --bail
 	@newman run postman/collections/graviteeio-am-user-management-collection.json -e postman/environment/dev.json --ignore-redirects --insecure --bail
 
 oidctest-run: oidctest-install oidctest-start ## Run openid-certification tools, using same docker network

--- a/gravitee-am-common/src/main/java/io/gravitee/am/common/oauth2/GrantType.java
+++ b/gravitee-am-common/src/main/java/io/gravitee/am/common/oauth2/GrantType.java
@@ -55,14 +55,20 @@ public interface GrantType {
      *
      * See <a href="https://tools.ietf.org/html/rfc7523#section-2.1">2.1. Using JWTs as Authorization Grant</a>
      */
-    String JWT_BEARER ="urn:ietf:params:oauth:grant-type:jwt-bearer";
+    String JWT_BEARER = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+
+    /**
+     * Device code flow
+     * See <a href="https://tools.ietf.org/html/draft-ietf-oauth-device-flow-15#section-3.4">3.4 Device Access Token Request</a>
+     */
+    String DEVIDE_CODE = "urn:ietf:params:oauth:grant-type:device_code";
 
     /**
      * SAML 2.0 Bearer
      *
      * See <a href="https://tools.ietf.org/html/rfc7522#section-2.1">2.1. Using SAML Assertions as Authorization Grants</a>
      */
-    String SAML2_BEARER ="urn:ietf:params:oauth:grant-type:saml2-bearer";
+    String SAML2_BEARER = "urn:ietf:params:oauth:grant-type:saml2-bearer";
 
     /**
      * Hybrid

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/jwt/JWTServiceTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/test/java/io/gravitee/am/gateway/handler/common/jwt/JWTServiceTest.java
@@ -18,7 +18,6 @@ package io.gravitee.am.gateway.handler.common.jwt;
 import io.gravitee.am.common.jwt.JWT;
 import io.gravitee.am.gateway.handler.common.certificate.CertificateManager;
 import io.gravitee.am.gateway.handler.common.jwt.impl.JWTServiceImpl;
-import io.gravitee.am.gateway.handler.common.vertx.utils.UriBuilderRequest;
 import io.gravitee.am.model.Client;
 import io.reactivex.Maybe;
 import io.reactivex.observers.TestObserver;
@@ -29,11 +28,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.Date;
-
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * @author Alexandre FARIA (contact at alexandrefaria.net)

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/discovery/impl/OpenIDDiscoveryServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/discovery/impl/OpenIDDiscoveryServiceImpl.java
@@ -26,6 +26,8 @@ import io.gravitee.am.gateway.handler.oidc.service.discovery.OpenIDDiscoveryServ
 import io.gravitee.am.gateway.handler.oidc.service.discovery.OpenIDProviderMetadata;
 import io.gravitee.am.gateway.handler.oidc.service.utils.SubjectTypeUtils;
 import io.gravitee.am.model.Domain;
+import io.gravitee.am.service.utils.GrantTypeUtils;
+import io.gravitee.am.service.utils.ResponseTypeUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Arrays;
@@ -72,8 +74,8 @@ public class OpenIDDiscoveryServiceImpl implements OpenIDDiscoveryService {
 
         // supported parameters
         openIDProviderMetadata.setScopesSupported(Stream.of(Scope.values()).map(Scope::getKey).collect(Collectors.toList()));
-        openIDProviderMetadata.setResponseTypesSupported(Arrays.asList(ResponseType.CODE, ResponseType.TOKEN, io.gravitee.am.common.oidc.ResponseType.ID_TOKEN, io.gravitee.am.common.oidc.ResponseType.ID_TOKEN_TOKEN, io.gravitee.am.common.oidc.ResponseType.CODE_ID_TOKEN, io.gravitee.am.common.oidc.ResponseType.CODE_TOKEN, io.gravitee.am.common.oidc.ResponseType.CODE_ID_TOKEN_TOKEN));
-        openIDProviderMetadata.setGrantTypesSupported(Arrays.asList(GrantType.CLIENT_CREDENTIALS, GrantType.PASSWORD, GrantType.IMPLICIT, GrantType.AUTHORIZATION_CODE, GrantType.REFRESH_TOKEN, GrantType.JWT_BEARER));
+        openIDProviderMetadata.setResponseTypesSupported(ResponseTypeUtils.getSupportedResponseTypes());
+        openIDProviderMetadata.setGrantTypesSupported(GrantTypeUtils.getSupportedGrantTypes());
         openIDProviderMetadata.setIdTokenSigningAlgValuesSupported(JWAlgorithmUtils.getSupportedIdTokenSigningAlg());
         openIDProviderMetadata.setIdTokenEncryptionAlgValuesSupported(JWAlgorithmUtils.getSupportedIdTokenResponseAlg());
         openIDProviderMetadata.setIdTokenEncryptionEncValuesSupported(JWAlgorithmUtils.getSupportedIdTokenResponseEnc());

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/utils/ResponseTypeUtils.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/utils/ResponseTypeUtils.java
@@ -32,21 +32,25 @@ import static io.gravitee.am.common.oidc.ResponseType.*;
  */
 public class ResponseTypeUtils {
 
-    private static final Set<String> VALID_RESPONSE_TYPES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+    private static final Set<String> SUPPORTED_RESPONSE_TYPES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
             CODE, TOKEN, ID_TOKEN, ID_TOKEN_TOKEN, CODE_TOKEN, CODE_ID_TOKEN, CODE_ID_TOKEN_TOKEN
     )));
 
+    public static List<String> getSupportedResponseTypes() {
+        return Collections.unmodifiableList(SUPPORTED_RESPONSE_TYPES.stream().sorted().collect(Collectors.toList()));
+    }
+
     /**
-     * Throw InvalidClientMetadataException if null or empty, or contains unknown response types.
+     * Throw InvalidClientMetadataException if null, or contains unknown response types.
      * @param responseTypes Array of response_type to validate.
      */
-    public static boolean isValidResponseType(List<String> responseTypes) {
-        if (responseTypes == null || responseTypes.isEmpty()) {
+    public static boolean isSupportedResponseType(List<String> responseTypes) {
+        if (responseTypes == null) {
             return false;
         }
 
         for (String responseType : responseTypes) {
-            if (!isValidResponseType(responseType)) {
+            if (!isSupportedResponseType(responseType)) {
                 return false;
             }
         }
@@ -58,8 +62,8 @@ public class ResponseTypeUtils {
      * Throw InvalidClientMetadataException if null or contains unknown response types.
      * @param responseType String to response_type validate.
      */
-    public static boolean isValidResponseType(String responseType) {
-        return VALID_RESPONSE_TYPES.contains(responseType);
+    public static boolean isSupportedResponseType(String responseType) {
+        return SUPPORTED_RESPONSE_TYPES.contains(responseType);
     }
 
     /**

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/utils/UriBuilder.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/utils/UriBuilder.java
@@ -30,43 +30,45 @@ import java.util.regex.Pattern;
  */
 public class UriBuilder {
 
-    private static final Pattern QUERY_PARAM_PATTERN = Pattern.compile("([^&=]+)(=?)([^&]+)?");
+    //private static final Pattern QUERY_PARAM_PATTERN = Pattern.compile("([^&=]+)(=?)([^&]+)?");
 
-    private static final String SCHEME_PATTERN = "([^:/?#]+):";
+    private static final String SCHEME_REGEX = "([^:/?#]+):";
 
-    private static final String HTTP_PATTERN = "(?i)(http|https):";
+    private static final String HTTP_REGEX = "(?i)(http|https):";
 
-    private static final String USERINFO_PATTERN = "([^@\\[/?#]*)";
+    private static final String USERINFO_REGEX = "([^@\\[/?#]*)";
 
-    private static final String HOST_IPV4_PATTERN = "[^\\[/?#:]*";
+    private static final String HOST_IPV4_REGEX = "[^\\[/?#:]*";
 
-    private static final String HOST_IPV6_PATTERN = "\\[[\\p{XDigit}\\:\\.]*[%\\p{Alnum}]*\\]";
+    private static final String HOST_IPV6_REGEX = "\\[[\\p{XDigit}\\:\\.]*[%\\p{Alnum}]*\\]";
 
-    private static final String HOST_PATTERN = "(" + HOST_IPV6_PATTERN + "|" + HOST_IPV4_PATTERN + ")";
+    private static final String HOST_REGEX = "(" + HOST_IPV6_REGEX + "|" + HOST_IPV4_REGEX + ")";
 
-    private static final String PORT_PATTERN = "(\\d*(?:\\{[^/]+?\\})?)";
+    private static final String PORT_REGEX = "(\\d*(?:\\{[^/]+?\\})?)";
 
-    private static final String PATH_PATTERN = "([^?#]*)";
+    private static final String PATH_REGEX = "([^?#]*)";
 
-    private static final String QUERY_PATTERN = "([^#]*)";
+    private static final String QUERY_REGEX = "([^#]*)";
 
-    private static final String LAST_PATTERN = "(.*)";
+    private static final String LAST_REGEX = "(.*)";
 
     // Regex patterns that matches URIs. See RFC 3986, appendix B
     private static final Pattern URI_PATTERN = Pattern.compile(
-            "^(" + SCHEME_PATTERN + ")?" + "(//(" + USERINFO_PATTERN + "@)?" + HOST_PATTERN + "(:" + PORT_PATTERN +
-                    ")?" + ")?" + PATH_PATTERN + "(\\?" + QUERY_PATTERN + ")?" + "(#" + LAST_PATTERN + ")?");
+            "^(" + SCHEME_REGEX + ")?" + "(//(" + USERINFO_REGEX + "@)?" + HOST_REGEX + "(:" + PORT_REGEX +
+                    ")?" + ")?" + PATH_REGEX + "(\\?" + QUERY_REGEX + ")?" + "(#" + LAST_REGEX + ")?");
 
     private static final Pattern HTTP_URL_PATTERN = Pattern.compile(
-            "^" + HTTP_PATTERN + "(//(" + USERINFO_PATTERN + "@)?" + HOST_PATTERN + "(:" + PORT_PATTERN +
-                    ")?" + ")?" + PATH_PATTERN + "(\\?" + QUERY_PATTERN + ")?" + "(#" + LAST_PATTERN + ")?");
+            "^" + HTTP_REGEX + "(//(" + USERINFO_REGEX + "@)?" + HOST_REGEX + "(:" + PORT_REGEX +
+                    ")?" + ")?" + PATH_REGEX + "(\\?" + QUERY_REGEX + ")?" + "(#" + LAST_REGEX + ")?");
 
-    private static final String LOCALHOST_HOST_PATTERN = "^localhost$";
-    private static final String LOCALHOST_IPV4_PATTERN = "^127(?:\\.[0-9]+){0,2}\\.[0-9]+$";
-    private static final String LOCALHOST_IPV6_PATTERN = "^(?:0*\\:)*?:?0*1$";
+    private static final Pattern HTTP_PATTERN = Pattern.compile(HTTP_REGEX.replace(":",""));
+
+    private static final String LOCALHOST_HOST_REGEX = "^localhost$";
+    private static final String LOCALHOST_IPV4_REGEX = "^127(?:\\.[0-9]+){0,2}\\.[0-9]+$";
+    private static final String LOCALHOST_IPV6_REGEX = "^(?:0*\\:)*?:?0*1$";
 
     private static final Pattern LOCALHOST_PATTERN = Pattern.compile(
-            LOCALHOST_HOST_PATTERN +"|"+LOCALHOST_IPV4_PATTERN+"|"+ LOCALHOST_IPV6_PATTERN);
+            LOCALHOST_HOST_REGEX +"|"+ LOCALHOST_IPV4_REGEX +"|"+ LOCALHOST_IPV6_REGEX);
 
     private String scheme;
     private String host;
@@ -212,6 +214,10 @@ public class UriBuilder {
 
     public URI build() throws URISyntaxException {
         return new URI(scheme, userInfo, host, port, path, query, fragment);
+    }
+
+    public static boolean isHttp(String scheme) {
+        return HTTP_PATTERN.matcher(scheme.toLowerCase()).matches();
     }
 
     public static boolean isLocalhost(String host) {

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/utils/ResponseTypeUtilsTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/utils/ResponseTypeUtilsTest.java
@@ -21,9 +21,9 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.util.Arrays;
+import java.util.List;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * @author Alexandre FARIA (contact at alexandrefaria.net)
@@ -34,7 +34,7 @@ public class ResponseTypeUtilsTest {
 
     @Test
     public void test_code_token_id_token() {
-        boolean isValid = ResponseTypeUtils.isValidResponseType(Arrays.asList(
+        boolean isValid = ResponseTypeUtils.isSupportedResponseType(Arrays.asList(
                 "code", "token", "id_token",
                 "id_token token", "code token", "code id_token","code id_token token")
         );
@@ -43,16 +43,21 @@ public class ResponseTypeUtilsTest {
 
     @Test
     public void test_unknown_response_type() {
-        boolean isValid = ResponseTypeUtils.isValidResponseType(Arrays.asList("code token id_token"));
+        boolean isValid = ResponseTypeUtils.isSupportedResponseType(Arrays.asList("code token id_token"));
         assertFalse("Were expecting to be false",isValid);
     }
 
     @Test
     public void test_empty_response_type() {
-        boolean isValid = ResponseTypeUtils.isValidResponseType(Arrays.asList());
-        assertFalse("Were expecting to be false",isValid);
+        boolean isValid = ResponseTypeUtils.isSupportedResponseType(Arrays.asList());
+        assertTrue("Were expecting to be true",isValid);//Can be empty for client_credentials...
     }
 
+    @Test
+    public void test_null_response_type() {
+        boolean isValid = ResponseTypeUtils.isSupportedResponseType((List<String>)null);
+        assertFalse("Were expecting to be false",isValid);//Can be empty for client_credentials...
+    }
     @Test
     public void applyDefaultResponseType() {
         Client client = new Client();
@@ -98,5 +103,11 @@ public class ResponseTypeUtilsTest {
         assertTrue(ResponseTypeUtils.requireNonce("code id_token token"));
         assertTrue(ResponseTypeUtils.requireNonce("id_token"));
         assertTrue(ResponseTypeUtils.requireNonce("id_token token"));
+    }
+
+    @Test
+    public void supportedResponseTypes() {
+        assertTrue("should have at least code", ResponseTypeUtils.getSupportedResponseTypes().contains("code"));
+        assertTrue("should have at least token", ResponseTypeUtils.getSupportedResponseTypes().contains("token"));
     }
 }

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/utils/UriBuilderTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/utils/UriBuilderTest.java
@@ -23,6 +23,7 @@ import org.junit.runners.Parameterized;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.StringJoiner;
 
 import static org.junit.runners.Parameterized.Parameters;
 
@@ -41,8 +42,9 @@ public class UriBuilderTest {
     private String path;
     private String query;
     private String fragment;
+    private boolean isHttp;
 
-    public UriBuilderTest(String uri, int port, String[] params) {
+    public UriBuilderTest(String uri, int port, String[] params, boolean isHttp) {
         this.uri = uri;
         this.port = port;
         this.scheme = params[0];
@@ -51,18 +53,19 @@ public class UriBuilderTest {
         this.path = params[3];
         this.query = params[4];
         this.fragment = params[5];
+        this.isHttp = isHttp;
     }
 
     @Parameters(name="Testing {0}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
-                {"http://localhost:8080/callback",8080,Arrays.asList("http","localhost",null,"/callback",null,null).toArray(new String[8])},
-                {"https://admin:password@localhost/callback",-1,Arrays.asList("https","localhost","admin:password","/callback",null,null).toArray(new String[8])},
-                {"https://gravitee.is?the=best",-1,Arrays.asList("https","gravitee.is",null,"","the=best",null).toArray(new String[8])},
-                {"myapp://callback#token=fragment",-1,Arrays.asList("myapp","callback",null,"",null,"token=fragment").toArray(new String[8])},
+                {"http://localhost:8080/callback",8080,Arrays.asList("http","localhost",null,"/callback",null,null).toArray(new String[6]),true},
+                {"https://admin:password@localhost/callback",-1,Arrays.asList("https","localhost","admin:password","/callback",null,null).toArray(new String[6]),true},
+                {"https://gravitee.is?the=best",-1,Arrays.asList("https","gravitee.is",null,"","the=best",null).toArray(new String[6]),true},
+                {"myapp://callback#token=fragment",-1,Arrays.asList("myapp","callback",null,"",null,"token=fragment").toArray(new String[6]),false},
                 {"https://op-test:60001/requests/something?the=best#fragment",60001,
-                        Arrays.asList("https","op-test",null,"/requests/something","the=best","fragment").toArray(new String[8])}
-
+                        Arrays.asList("https","op-test",null,"/requests/something","the=best","fragment").toArray(new String[6]),true},
+                {"com.google.app:/callback",-1,Arrays.asList("com.google.app",null,null,"/callback",null,null).toArray(new String[6]),false}
         });
     }
 
@@ -76,11 +79,12 @@ public class UriBuilderTest {
         Assert.assertEquals("path",this.path,uri.getPath());
         Assert.assertEquals("query",this.query,uri.getQuery());
         Assert.assertEquals("fragment",this.fragment,uri.getFragment());
+        Assert.assertEquals("Scheme isHttp does not match",this.isHttp, UriBuilder.isHttp(uri.getScheme()));
     }
 
     @Test
     public void testFromHttp() throws Exception{
-        if(this.uri.trim().startsWith("http")) {
+        if(this.isHttp) {
             URI uri = UriBuilder.fromHttpUrl(this.uri).build();
             Assert.assertEquals("scheme",this.scheme,uri.getScheme());
             Assert.assertEquals("user info",this.userinfo,uri.getUserInfo());
@@ -89,10 +93,11 @@ public class UriBuilderTest {
             Assert.assertEquals("path",this.path,uri.getPath());
             Assert.assertEquals("query",this.query,uri.getQuery());
             Assert.assertEquals("fragment",this.fragment,uri.getFragment());
+            Assert.assertEquals("Scheme isHttp does not match",this.isHttp, UriBuilder.isHttp(uri.getScheme()));
         }else {
             boolean assertThrowException = false;
             try {
-                URI uri = UriBuilder.fromHttpUrl(this.uri).build();
+                UriBuilder.fromHttpUrl(this.uri).build();
             } catch (IllegalArgumentException ex) {
                 assertThrowException = true;
             }

--- a/gravitee-am-ui/src/app/domain/clients/client/settings/settings.component.html
+++ b/gravitee-am-ui/src/app/domain/clients/client/settings/settings.component.html
@@ -219,7 +219,8 @@
         <b><i>authorization_code</i></b> for server side applications (web) or native applications (then combined with PKCE).<br>
         <b><i>implicit</i></b> must be used for Single Page Applications.<br>
         <b><i>password</i></b> should only be used for trusted applications <i>(means application and authorization server are managed within the same organization.)</i><br>
-        <b><i>client_credentials</i></b> should be used for server to server communications.<br>
+        <b><i>client_credentials</i></b> should be used for server to server communications.<br><br>
+        <b>It is not recommended to mix client and user authentication within the same application.</b> <i>(Aka client_credentials and authorization_code, implicit or password)</i><br>
     </small>
   </div>
   <h3>Response types</h3>
@@ -235,7 +236,7 @@
       <b><i>token id_token:</i></b> implicit<br>
       <b><i>code id_token:</i></b> authorization_code, implicit<br>
       <b><i>code token:</i></b> authorization_code, implicit<br>
-      <b><i>code token id_token:</i></b> authorization_code, implicit<br>
+      <b><i>code id_token token:</i></b> authorization_code, implicit<br>
     </small>
 
   </div>

--- a/gravitee-am-ui/src/app/domain/clients/client/settings/settings.component.ts
+++ b/gravitee-am-ui/src/app/domain/clients/client/settings/settings.component.ts
@@ -46,11 +46,11 @@ export class ClientSettingsComponent implements OnInit {
   identityProviders: any[] = [];
   certificates: any[] = [];
   scopes: any[] = [];
-  //responseTypes: any[] = ['code','token','id_token','id_token token','code token','code token id_token'];
+  //responseTypes: any[] = ['code','token','id_token','id_token token','code token','code id_token token'];
   responseTypes: any[] = [
     { value:'code', checked:false },
-    { value:'token', checked:false },
-    { value:'id_token', checked:false }
+    { value:'id_token', checked:false },
+    { value:'token', checked:false }
   ];
   grantTypes: any[] = [
     { name:'AUTHORIZATION CODE', value:'authorization_code', checked:false },

--- a/postman/collections/graviteeio-am-client-management-collection.json
+++ b/postman/collections/graviteeio-am-client-management-collection.json
@@ -1,0 +1,916 @@
+{
+	"info": {
+		"_postman_id": "73100933-53f5-45a2-9daa-1ca3bc04a523",
+		"name": "Gravitee.io - AM - Client Management",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Prepare",
+			"item": [
+				{
+					"name": "Generate admin token",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "571e9b59-b9e7-452c-9469-9786ded290a6",
+								"exec": [
+									"",
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"var token = JSON.parse(responseBody);",
+									"pm.environment.set('token', token.access_token);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Basic YWRtaW46YWRtaW5hZG1pbg=="
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "grant_type",
+									"value": "password",
+									"type": "text"
+								},
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "text"
+								},
+								{
+									"key": "password",
+									"value": "adminadmin",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{management_url}}/admin/token",
+							"host": [
+								"{{management_url}}"
+							],
+							"path": [
+								"admin",
+								"token"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create client management domain",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "b286f0fa-cfcc-45b9-863a-1dbc87fdf835",
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"var jsonData = pm.response.json();",
+									"pm.environment.set('domain', jsonData.id);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"name\": \"client-domain\", \n\t\"description\": \"test client management through Access Management API\"\n}"
+						},
+						"url": {
+							"raw": "{{management_url}}/management/domains/",
+							"host": [
+								"{{management_url}}"
+							],
+							"path": [
+								"management",
+								"domains",
+								""
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Start domain",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "bfe78ac1-144a-4bbd-abf9-55e160e723bf",
+								"exec": [
+									"// wait for sync process",
+									"setTimeout(function(){}, 5000);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"enabled\": true\n}"
+						},
+						"url": {
+							"raw": "{{management_url}}/management/domains/{{domain}}",
+							"host": [
+								"{{management_url}}"
+							],
+							"path": [
+								"management",
+								"domains",
+								"{{domain}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "well-known/openid-configuration",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "5332b6f5-7419-4792-a30f-cce968d3d67e",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Check discovery endpoints\", function () {",
+									"    pm.response.to.be.header('Content-Type', 'application/json');",
+									"    var body = pm.response.json();",
+									"    ",
+									"    pm.expect(body).to.have.property(\"token_endpoint\");",
+									"    pm.environment.set('tokenEndpoint', body.token_endpoint);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{gateway_url}}/{{domain}}/oidc/.well-known/openid-configuration",
+							"host": [
+								"{{gateway_url}}"
+							],
+							"path": [
+								"{{domain}}",
+								"oidc",
+								".well-known",
+								"openid-configuration"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Client Management",
+			"item": [
+				{
+					"name": "Invalid Case",
+					"item": [
+						{
+							"name": "Create client",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fbe2362d-ad75-4baa-8825-b74218b047c7",
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"pm.test(\"grant and response types are empty\", function () {",
+											"    var body = JSON.parse(responseBody);",
+											"    pm.environment.set('client', body.id);",
+											"",
+											"    pm.expect(body).to.have.property('authorizedGrantTypes');",
+											"    pm.expect(body).to.have.property('responseTypes');",
+											"    pm.expect(body.authorizedGrantTypes).to.eql([]);",
+											"    pm.expect(body.responseTypes).to.eql([]);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"clientId\": \"my-client\",\n  \"clientSecret\": \"my-client-secret\"\n}"
+								},
+								"url": {
+									"raw": "{{management_url}}/management/domains/{{domain}}/clients",
+									"host": [
+										"{{management_url}}"
+									],
+									"path": [
+										"management",
+										"domains",
+										"{{domain}}",
+										"clients"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "missing redirect_uris",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "c37cba72-91c2-4850-80cd-6fd3908e406e",
+										"exec": [
+											"pm.test(\"Status code is 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"missing redirect_uri\", function () {",
+											"    var body = JSON.parse(responseBody);",
+											"    pm.expect(body).to.have.property('message');",
+											"    pm.expect(body.message).to.eql('Missing or invalid redirect_uris.');",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"redirectUris\": [],\n  \"authorizedGrantTypes\": [\"implicit\"],\n  \"responseTypes\": [\"token\"]\n}"
+								},
+								"url": {
+									"raw": "{{management_url}}/management/domains/{{domain}}/clients/{{client}}",
+									"host": [
+										"{{management_url}}"
+									],
+									"path": [
+										"management",
+										"domains",
+										"{{domain}}",
+										"clients",
+										"{{client}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "missing grant associated to refresh_token",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "c37cba72-91c2-4850-80cd-6fd3908e406e",
+										"exec": [
+											"pm.test(\"Status code is 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"missing redirect_uri\", function () {",
+											"    var body = JSON.parse(responseBody);",
+											"    pm.expect(body).to.have.property('message');",
+											"    pm.expect(body.message).to.contains('refresh_token grant type must be associated with one of');",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"redirectUris\": [],\n  \"authorizedGrantTypes\": [\"refresh_token\"],\n  \"responseTypes\": []\n}"
+								},
+								"url": {
+									"raw": "{{management_url}}/management/domains/{{domain}}/clients/{{client}}",
+									"host": [
+										"{{management_url}}"
+									],
+									"path": [
+										"management",
+										"domains",
+										"{{domain}}",
+										"clients",
+										"{{client}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "client_credentials does not manage refresh_token",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "c37cba72-91c2-4850-80cd-6fd3908e406e",
+										"exec": [
+											"pm.test(\"Status code is 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"missing redirect_uri\", function () {",
+											"    var body = JSON.parse(responseBody);",
+											"    pm.expect(body).to.have.property('message');",
+											"    pm.expect(body.message).to.contains('refresh_token grant type must be associated with one of');",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"redirectUris\": [],\n  \"authorizedGrantTypes\": [\"refresh_token\",\"client_credentials\"],\n  \"responseTypes\": []\n}"
+								},
+								"url": {
+									"raw": "{{management_url}}/management/domains/{{domain}}/clients/{{client}}",
+									"host": [
+										"{{management_url}}"
+									],
+									"path": [
+										"management",
+										"domains",
+										"{{domain}}",
+										"clients",
+										"{{client}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete client",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fbe2362d-ad75-4baa-8825-b74218b047c7",
+										"exec": [
+											"pm.test(\"Status code is 204\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"clientId\": \"my-client\",\n  \"clientSecret\": \"my-client-secret\"\n}"
+								},
+								"url": {
+									"raw": "{{management_url}}/management/domains/{{domain}}/clients/{{client}}",
+									"host": [
+										"{{management_url}}"
+									],
+									"path": [
+										"management",
+										"domains",
+										"{{domain}}",
+										"clients",
+										"{{client}}"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "Nominal Case",
+					"item": [
+						{
+							"name": "Create client",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fbe2362d-ad75-4baa-8825-b74218b047c7",
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"",
+											"pm.test(\"default values\", function () {",
+											"    var body = JSON.parse(responseBody);",
+											"    pm.environment.set('client', body.id);",
+											"",
+											"    pm.expect(body).to.have.property('authorizedGrantTypes');",
+											"    pm.expect(body).to.have.property('responseTypes');",
+											"    pm.expect(body).to.have.property('applicationType');",
+											"",
+											"    pm.expect(body.authorizedGrantTypes).to.eql([]);",
+											"    pm.expect(body.responseTypes).to.eql([]);",
+											"    pm.expect(body.applicationType).to.eql('web');",
+											"    ",
+											"    pm.expect(body.clientName).to.eql('Unknown Client');",
+											"    pm.expect(body.tokenEndpointAuthMethod).to.eql('client_secret_basic');",
+											"    pm.expect(body.requireAuthTime).to.eql(false);",
+											"    pm.expect(body.accessTokenValiditySeconds).to.eql(7200);",
+											"    pm.expect(body.refreshTokenValiditySeconds).to.eql(14400);",
+											"    pm.expect(body.idTokenValiditySeconds).to.eql(14400);",
+											"    pm.expect(body.domain).to.eql(pm.environment.get('domain'));",
+											"    pm.expect(body.enabled).to.eql(true);",
+											"    pm.expect(body.enhanceScopesWithUserPermissions).to.eql(false);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"clientId\": \"my-client\",\n  \"clientSecret\": \"my-client-secret\"\n}"
+								},
+								"url": {
+									"raw": "{{management_url}}/management/domains/{{domain}}/clients",
+									"host": [
+										"{{management_url}}"
+									],
+									"path": [
+										"management",
+										"domains",
+										"{{domain}}",
+										"clients"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Web application - authorization_code",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "c37cba72-91c2-4850-80cd-6fd3908e406e",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"is webapp\", function () {",
+											"    var body = JSON.parse(responseBody);",
+											"    pm.expect(body).to.have.property('redirectUris');",
+											"    pm.expect(body).to.have.property('authorizedGrantTypes');",
+											"    pm.expect(body).to.have.property('responseTypes');",
+											"    pm.expect(body).to.have.property('applicationType');",
+											"",
+											"    pm.expect(body.redirectUris).to.eql(['https://callback']);",
+											"    pm.expect(body.authorizedGrantTypes).to.eql(['authorization_code']);",
+											"    pm.expect(body.responseTypes).to.eql(['code']);//default value",
+											"    pm.expect(body.applicationType).to.eql('web');//default value",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"redirectUris\": [\"https://callback\"],\n  \"authorizedGrantTypes\": [\"authorization_code\"],\n  \"scopes\": [\"openid\"]\n}"
+								},
+								"url": {
+									"raw": "{{management_url}}/management/domains/{{domain}}/clients/{{client}}",
+									"host": [
+										"{{management_url}}"
+									],
+									"path": [
+										"management",
+										"domains",
+										"{{domain}}",
+										"clients",
+										"{{client}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Single Page Application - Implicit",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "c37cba72-91c2-4850-80cd-6fd3908e406e",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"is Single Page Application\", function () {",
+											"    var body = JSON.parse(responseBody);",
+											"    pm.expect(body).to.have.property('authorizedGrantTypes');",
+											"    pm.expect(body).to.have.property('responseTypes');",
+											"    pm.expect(body.authorizedGrantTypes).to.eql(['implicit']);",
+											"    pm.expect(body.responseTypes).to.eql(['token']);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"redirectUris\": [\"https://callback\"],\n  \"authorizedGrantTypes\": [\"implicit\"],\n  \"responseTypes\": [\"token\"],\n  \"scopes\": [\"openid\"]\n}"
+								},
+								"url": {
+									"raw": "{{management_url}}/management/domains/{{domain}}/clients/{{client}}",
+									"host": [
+										"{{management_url}}"
+									],
+									"path": [
+										"management",
+										"domains",
+										"{{domain}}",
+										"clients",
+										"{{client}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Mobile application - authorization_code",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "c37cba72-91c2-4850-80cd-6fd3908e406e",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"is mobile\", function () {",
+											"    var body = JSON.parse(responseBody);",
+											"    pm.expect(body).to.have.property('redirectUris');",
+											"    pm.expect(body).to.have.property('authorizedGrantTypes');",
+											"    pm.expect(body).to.have.property('responseTypes');",
+											"    pm.expect(body).to.have.property('applicationType');",
+											"",
+											"    pm.expect(body.redirectUris).to.eql(['com.gravitee.app://callback']);",
+											"    pm.expect(body.authorizedGrantTypes).to.eql(['authorization_code','refresh_token']);",
+											"    pm.expect(body.responseTypes).to.eql(['code']);",
+											"    pm.expect(body.applicationType).to.eql('native');",
+											"    ",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"redirectUris\": [\"com.gravitee.app://callback\"],\n  \"authorizedGrantTypes\": [\"authorization_code\",\"refresh_token\"],\n  \"applicationType\": \"native\",\n  \"scopes\": [\"openid\"]\n}"
+								},
+								"url": {
+									"raw": "{{management_url}}/management/domains/{{domain}}/clients/{{client}}",
+									"host": [
+										"{{management_url}}"
+									],
+									"path": [
+										"management",
+										"domains",
+										"{{domain}}",
+										"clients",
+										"{{client}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Server application - client_credentials",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "c37cba72-91c2-4850-80cd-6fd3908e406e",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"is server\", function () {",
+											"    var body = JSON.parse(responseBody);",
+											"    pm.expect(body).to.have.property('redirectUris');",
+											"    pm.expect(body).to.have.property('authorizedGrantTypes');",
+											"    pm.expect(body).to.have.property('responseTypes');",
+											"    pm.expect(body).to.have.property('applicationType');",
+											"",
+											"    pm.expect(body.redirectUris).to.eql([]);",
+											"    pm.expect(body.authorizedGrantTypes).to.eql(['client_credentials']);",
+											"    pm.expect(body.responseTypes).to.eql([]);",
+											"    pm.expect(body.applicationType).to.eql('server');",
+											"    ",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"redirectUris\": [],\n  \"authorizedGrantTypes\": [\"client_credentials\"],\n  \"responseTypes\": [],\n  \"applicationType\": \"server\",\n  \"scopes\": [\"openid\"]\n}"
+								},
+								"url": {
+									"raw": "{{management_url}}/management/domains/{{domain}}/clients/{{client}}",
+									"host": [
+										"{{management_url}}"
+									],
+									"path": [
+										"management",
+										"domains",
+										"{{domain}}",
+										"clients",
+										"{{client}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete client",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "fbe2362d-ad75-4baa-8825-b74218b047c7",
+										"exec": [
+											"pm.test(\"Status code is 204\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"clientId\": \"my-client\",\n  \"clientSecret\": \"my-client-secret\"\n}"
+								},
+								"url": {
+									"raw": "{{management_url}}/management/domains/{{domain}}/clients/{{client}}",
+									"host": [
+										"{{management_url}}"
+									],
+									"path": [
+										"management",
+										"domains",
+										"{{domain}}",
+										"clients",
+										"{{client}}"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				}
+			]
+		},
+		{
+			"name": "Delete domain",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "abfa8366-3ee2-45b0-b658-0040b79d565c",
+						"exec": [
+							"pm.test(\"Status code is 204\", function () {",
+							"    pm.response.to.have.status(204);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "DELETE",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "Authorization",
+						"value": "Bearer {{token}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "{{management_url}}/management/domains/{{domain}}",
+					"host": [
+						"{{management_url}}"
+					],
+					"path": [
+						"management",
+						"domains",
+						"{{domain}}"
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/postman/collections/graviteeio-am-login-collection.json
+++ b/postman/collections/graviteeio-am-login-collection.json
@@ -248,7 +248,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"redirectUris\": [],\n  \"authorizedGrantTypes\": [\n    \"authorization_code\",\n    \"client_credentials\",\n    \"implicit\",\n    \"password\",\n    \"refresh_token\"\n  ],\n  \"scopes\": [\"openid\"],\n  \"accessTokenValiditySeconds\": 7200,\n  \"refreshTokenValiditySeconds\": 14400,\n  \"idTokenValiditySeconds\": 14400,\n  \"idTokenCustomClaims\": {},\n  \"enabled\": true,\n  \"identities\": [\n    \"{{idp.inmemory}}\"\n  ],\n  \"enhanceScopesWithUserPermissions\": false\n}"
+							"raw": "{\n  \"redirectUris\": [],\n  \"authorizedGrantTypes\": [\n    \"authorization_code\",\n    \"client_credentials\",\n    \"password\",\n    \"refresh_token\"\n  ],\n  \"scopes\": [\"openid\"],\n  \"accessTokenValiditySeconds\": 7200,\n  \"refreshTokenValiditySeconds\": 14400,\n  \"idTokenValiditySeconds\": 14400,\n  \"idTokenCustomClaims\": {},\n  \"enabled\": true,\n  \"identities\": [\n    \"{{idp.inmemory}}\"\n  ],\n  \"enhanceScopesWithUserPermissions\": false\n}"
 						},
 						"url": {
 							"raw": "{{management_url}}/management/domains/{{domain}}/clients/{{client}}",

--- a/postman/collections/graviteeio-am-oauth2-collection.json
+++ b/postman/collections/graviteeio-am-oauth2-collection.json
@@ -458,7 +458,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"redirectUris\": [],\n  \"authorizedGrantTypes\": [\n    \"authorization_code\",\n    \"client_credentials\",\n    \"implicit\",\n    \"password\",\n    \"refresh_token\"\n  ],\n  \"scopes\": [\"scope1\", \"openid\"],\n  \"accessTokenValiditySeconds\": 7200,\n  \"refreshTokenValiditySeconds\": 14400,\n  \"idTokenValiditySeconds\": 14400,\n  \"idTokenCustomClaims\": {},\n  \"enabled\": true,\n  \"identities\": [\n    \"{{idp.inmemory}}\"\n  ],\n  \"enhanceScopesWithUserPermissions\": false\n}"
+							"raw": "{\n  \"redirectUris\": [],\n  \"authorizedGrantTypes\": [\n    \"authorization_code\",\n    \"client_credentials\",\n    \"password\",\n    \"refresh_token\"\n  ],\n  \"scopes\": [\"scope1\", \"openid\"],\n  \"accessTokenValiditySeconds\": 7200,\n  \"refreshTokenValiditySeconds\": 14400,\n  \"idTokenValiditySeconds\": 14400,\n  \"idTokenCustomClaims\": {},\n  \"enabled\": true,\n  \"identities\": [\n    \"{{idp.inmemory}}\"\n  ],\n  \"enhanceScopesWithUserPermissions\": false\n}"
 						},
 						"url": {
 							"raw": "{{management_url}}/management/domains/{{domain}}/clients/{{client1}}",

--- a/postman/collections/graviteeio-am-openid-core-collection.json
+++ b/postman/collections/graviteeio-am-openid-core-collection.json
@@ -402,7 +402,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"redirectUris\": [],\n  \"authorizedGrantTypes\": [\n    \"authorization_code\",\n    \"client_credentials\",\n    \"implicit\",\n    \"password\",\n    \"refresh_token\"\n  ],\n  \"scopes\": [\"scope1\", \"openid\"],\n  \"accessTokenValiditySeconds\": 7200,\n  \"refreshTokenValiditySeconds\": 14400,\n  \"idTokenValiditySeconds\": 14400,\n  \"idTokenCustomClaims\": {},\n  \"enabled\": true,\n  \"identities\": [\n    \"{{idp.inmemory}}\"\n  ],\n  \"enhanceScopesWithUserPermissions\": false\n}"
+							"raw": "{\n  \"redirectUris\": [\"https://domain/callback\",\"https://another/callback\"],\n  \"authorizedGrantTypes\": [\n    \"authorization_code\",\n    \"client_credentials\",\n    \"implicit\",\n    \"password\",\n    \"refresh_token\"\n  ],\n  \"scopes\": [\"scope1\", \"openid\"],\n  \"accessTokenValiditySeconds\": 7200,\n  \"refreshTokenValiditySeconds\": 14400,\n  \"idTokenValiditySeconds\": 14400,\n  \"idTokenCustomClaims\": {},\n  \"enabled\": true,\n  \"identities\": [\n    \"{{idp.inmemory}}\"\n  ],\n  \"enhanceScopesWithUserPermissions\": false\n}"
 						},
 						"url": {
 							"raw": "{{management_url}}/management/domains/{{domain}}/clients/{{client1}}",
@@ -3025,7 +3025,7 @@
 													"    ",
 													"    tests['Redirect to error page'] = location.includes(pm.environment.get('gateway_url') + '/' + domain + '/oauth/error');",
 													"    tests['Contains an error query-parameter'] = location.includes('?error=invalid_request');",
-													"    tests['Contains an error description query-parameter'] = location.includes('error_description=A+redirect_uri+must+be+supplied');",
+													"    tests['Contains an error description query-parameter'] = location.includes('a+redirect_uri+must+be+supplied');",
 													"});"
 												],
 												"type": "text/javascript"
@@ -4704,7 +4704,7 @@
 													"    ",
 													"    tests['Redirect to error page'] = location.includes(pm.environment.get('gateway_url') + '/' + domain + '/oauth/error');",
 													"    tests['Contains an error query-parameter'] = location.includes('?error=invalid_request');",
-													"    tests['Contains an error description query-parameter'] = location.includes('error_description=A+redirect_uri+must+be+supplied');",
+													"    tests['Contains an error description query-parameter'] = location.includes('a+redirect_uri+must+be+supplied');",
 													"});"
 												],
 												"type": "text/javascript"

--- a/postman/collections/graviteeio-am-openid-dcr-collection.json
+++ b/postman/collections/graviteeio-am-openid-dcr-collection.json
@@ -135,7 +135,7 @@
 							"script": {
 								"id": "2e92f1ea-5d06-4aa3-9ddc-95b0359a8f20",
 								"exec": [
-									"pm.test(\"Status code is 201\", function () {",
+									"pm.test(\"Status code is 204\", function () {",
 									"    pm.response.to.have.status(204);",
 									"});"
 								],
@@ -255,6 +255,10 @@
 								"value": "Bearer {{token}}"
 							}
 						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
 						"url": {
 							"raw": "{{management_url}}/management/domains/{{domain}}/certificates",
 							"host": [
@@ -514,6 +518,10 @@
 					"request": {
 						"method": "GET",
 						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
 						"url": {
 							"raw": "{{gateway_url}}/{{domain}}/oidc/.well-known/openid-configuration",
 							"host": [
@@ -657,6 +665,9 @@
 									"pm.test(\"Has default attributes\", function () {",
 									"    var body = pm.response.json();",
 									"    pm.expect(body.client_name).to.eql('open_dcr_client');",
+									"    pm.expect(body.application_type).to.eql('web');",
+									"    pm.expect(body.grant_types[0]).to.eql('authorization_code');",
+									"    pm.expect(body.response_types[0]).to.eql('code');",
 									"    ",
 									"    pm.environment.set('newClientForDCRTests', body.id);",
 									"    pm.environment.set('registrationAccessToken', body.registration_access_token);",
@@ -678,7 +689,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n   \"client_name\": \"open_dcr_client\",\t\n   \"application_type\": \"web\",\n   \"redirect_uris\":\n     [\"https://client.example.org/callback\",\n      \"https://client.example.org/callback2\"],\n   \"logo_uri\": \"https://client.example.org/logo.png\",\n   \"subject_type\": \"public\",\n\t\"response_types\": [\"token\", \"code\", \"code token\"],\n   \"contacts\": [\"ve7jtb@example.org\", \"mary@example.org\"],\n   \"request_uris\":\n     [\"https://client.example.org/rf.txt#qpXaRLh_n93TTR9F252ValdatUQvQiJi5BDub2BeznA\"]\n  }"
+							"raw": "{\n   \"client_name\": \"open_dcr_client\",\t\n   \"redirect_uris\":\n     [\"https://client.example.org/callback\",\n      \"https://client.example.org/callback2\"],\n   \"logo_uri\": \"https://client.example.org/logo.png\",\n   \"subject_type\": \"public\",\n   \"contacts\": [\"ve7jtb@example.org\", \"mary@example.org\"],\n   \"request_uris\":\n     [\"https://client.example.org/rf.txt#qpXaRLh_n93TTR9F252ValdatUQvQiJi5BDub2BeznA\"]\n  }"
 						},
 						"url": {
 							"raw": "{{registrationEndpoint}}",
@@ -706,8 +717,8 @@
 									"    var body = pm.response.json();",
 									"    pm.expect(body).to.have.property(\"redirect_uris\");",
 									"    pm.expect(body).to.have.property(\"grant_types\");",
-									"    pm.expect(body.response_types).to.eql([ 'token','code','code token' ]);",
-									"    pm.expect(body.grant_types).to.eql([ 'implicit','authorization_code' ]);",
+									"    pm.expect(body.response_types).to.eql([ 'code' ]);//default value",
+									"    pm.expect(body.grant_types).to.eql([ 'authorization_code' ]);//default value",
 									"    ",
 									"    //The Authorization Server need not include the registration_access_token or registration_client_uri value in this response unless they have been updated.",
 									"    pm.expect(body).to.not.have.property('registration_access_token');",
@@ -732,6 +743,10 @@
 								"value": "Bearer {{registrationAccessToken}}"
 							}
 						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
 						"url": {
 							"raw": "{{registrationClientUri}}",
 							"host": [
@@ -759,6 +774,8 @@
 									"    pm.expect(body.client_name).to.eql('Client patched via DCR');",
 									"    pm.expect(body).to.have.property(\"response_types\");",
 									"    pm.expect(body.response_types).to.eql(['token', 'code', 'code id_token']);",
+									"    pm.expect(body).to.have.property(\"grant_types\");",
+									"    pm.expect(body.grant_types).to.eql(['implicit', 'authorization_code']);",
 									"});",
 									"",
 									"pm.test(\"One time Token\", function() {",
@@ -818,6 +835,8 @@
 									"    pm.expect(body.client_name).to.eql('Client name updated via DCR');",
 									"    pm.expect(body).to.have.property(\"response_types\");",
 									"    pm.expect(body.response_types).to.eql(['code']);",
+									"    pm.expect(body).to.have.property(\"grant_types\");",
+									"    pm.expect(body.grant_types).to.eql(['authorization_code']);",
 									"});",
 									"",
 									"pm.test(\"One time Token\", function() {",
@@ -1056,7 +1075,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"authorizedGrantTypes\": [\"client_credentials\"]\n}"
+							"raw": "{\n  \"authorizedGrantTypes\": [\"client_credentials\"],\n  \"responseTypes\": [],\n  \"applicationType\": \"server\"\n}"
 						},
 						"url": {
 							"raw": "{{management_url}}/management/domains/{{domain}}/clients/{{clientDCR}}",
@@ -1420,6 +1439,206 @@
 							"response": []
 						},
 						{
+							"name": "Invalid redirect uri - null - implicit grant",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "c557fd6b-d770-4568-8db7-ccb3267b0256",
+										"exec": [
+											"pm.test(\"Status code is 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"Redirect uris are missing\", function () {",
+											"    pm.response.to.be.header('Content-Type', 'application/json');",
+											"    var body = pm.response.json();",
+											"    pm.expect(body.error).to.eql('invalid_redirect_uri');",
+											"    pm.expect(body.error_description).to.eql('Missing or invalid redirect_uris.');",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"type": "text",
+										"value": "Bearer {{access_token}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"redirect_uris\": null,\n  \"grant_types\": [\"implicit\"],\n  \"response_types\": [\"token\"],\n  \"client_name\": \"My implicit Client\",\n  \"token_endpoint_auth_method\": \"client_secret_basic\",\n  \"logo_uri\": \"https://client.example.org/logo.png\"\n}"
+								},
+								"url": {
+									"raw": "{{registrationEndpoint}}",
+									"host": [
+										"{{registrationEndpoint}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Invalid redirect uri - empty - implicit grant",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "c557fd6b-d770-4568-8db7-ccb3267b0256",
+										"exec": [
+											"pm.test(\"Status code is 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"Redirect uris are missing\", function () {",
+											"    pm.response.to.be.header('Content-Type', 'application/json');",
+											"    var body = pm.response.json();",
+											"    pm.expect(body.error).to.eql('invalid_redirect_uri');",
+											"    pm.expect(body.error_description).to.eql('Missing or invalid redirect_uris.');",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"type": "text",
+										"value": "Bearer {{access_token}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"redirect_uris\": [],\n  \"grant_types\": [\"implicit\"],\n  \"response_types\": [\"token\"],\n  \"client_name\": \"My implicit Client\",\n  \"token_endpoint_auth_method\": \"client_secret_basic\",\n  \"logo_uri\": \"https://client.example.org/logo.png\"\n}"
+								},
+								"url": {
+									"raw": "{{registrationEndpoint}}",
+									"host": [
+										"{{registrationEndpoint}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Invalid redirect uri - no scheme uri",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "c557fd6b-d770-4568-8db7-ccb3267b0256",
+										"exec": [
+											"pm.test(\"Status code is 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"Redirect uris localhost forbidden\", function () {",
+											"    pm.response.to.be.header('Content-Type', 'application/json');",
+											"    var body = pm.response.json();",
+											"    pm.expect(body.error).to.eql('invalid_redirect_uri');",
+											"    pm.expect(body.error_description).to.eql('redirect_uri : no_scheme is malformed');",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"type": "text",
+										"value": "Bearer {{access_token}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"redirect_uris\": [\"no_scheme\"],\n  \"client_name\": \"My Example Client\",\n  \"token_endpoint_auth_method\": \"client_secret_basic\",\n  \"logo_uri\": \"https://client.example.org/logo.png\"\n}"
+								},
+								"url": {
+									"raw": "{{registrationEndpoint}}",
+									"host": [
+										"{{registrationEndpoint}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Invalid redirect uri - malformed uri",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "c557fd6b-d770-4568-8db7-ccb3267b0256",
+										"exec": [
+											"pm.test(\"Status code is 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"Redirect uris localhost forbidden\", function () {",
+											"    pm.response.to.be.header('Content-Type', 'application/json');",
+											"    var body = pm.response.json();",
+											"    pm.expect(body.error).to.eql('invalid_redirect_uri');",
+											"    pm.expect(body.error_description).to.eql('redirect_uri : malformed:uri:exception is malformed');",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"type": "text",
+										"value": "Bearer {{access_token}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"redirect_uris\": [\"malformed:uri:exception\"],\n  \"client_name\": \"My Example Client\",\n  \"token_endpoint_auth_method\": \"client_secret_basic\",\n  \"logo_uri\": \"https://client.example.org/logo.png\"\n}"
+								},
+								"url": {
+									"raw": "{{registrationEndpoint}}",
+									"host": [
+										"{{registrationEndpoint}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
 							"name": "Invalid redirect uri - localhost",
 							"event": [
 								{
@@ -1659,6 +1878,106 @@
 								"body": {
 									"mode": "raw",
 									"raw": "{\n  \"redirect_uris\": [\n    \"https://client.example.org/callback\",\n    \"https://client.example.org/callback2\"],\n  \"grant_types\": [\n\t\"unknown\"\n   ],\n  \"client_name\": \"My Example Client\",\n  \"token_endpoint_auth_method\": \"client_secret_basic\",\n  \"logo_uri\": \"https://client.example.org/logo.png\",\n  \"jwks_uri\": \"https://client.example.org/my_public_keys.jwks\"\n}"
+								},
+								"url": {
+									"raw": "{{registrationEndpoint}}",
+									"host": [
+										"{{registrationEndpoint}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Invalid grant type - empty",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "c557fd6b-d770-4568-8db7-ccb3267b0256",
+										"exec": [
+											"pm.test(\"Status code is 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"Invalid grant type\", function () {",
+											"    pm.response.to.be.header('Content-Type', 'application/json');",
+											"    var body = pm.response.json();",
+											"    pm.expect(body.error).to.eql('invalid_client_metadata');",
+											"    pm.expect(body.error_description).to.eql('Missing or invalid grant type.');",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"type": "text",
+										"value": "Bearer {{access_token}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"redirect_uris\": [\n    \"https://client.example.org/callback\",\n    \"https://client.example.org/callback2\"],\n  \"grant_types\": [],\n  \"client_name\": \"My Example Client\",\n  \"token_endpoint_auth_method\": \"client_secret_basic\",\n  \"logo_uri\": \"https://client.example.org/logo.png\",\n  \"jwks_uri\": \"https://client.example.org/my_public_keys.jwks\"\n}"
+								},
+								"url": {
+									"raw": "{{registrationEndpoint}}",
+									"host": [
+										"{{registrationEndpoint}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Invalid grant type - refresh_token alone",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "c557fd6b-d770-4568-8db7-ccb3267b0256",
+										"exec": [
+											"pm.test(\"Status code is 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"Invalid grant type\", function () {",
+											"    pm.response.to.be.header('Content-Type', 'application/json');",
+											"    var body = pm.response.json();",
+											"    pm.expect(body.error).to.eql('invalid_client_metadata');",
+											"    pm.expect(body.error_description).to.include('refresh_token grant type must be associated with one of');",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"type": "text",
+										"value": "Bearer {{access_token}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"redirect_uris\": [],\n  \"response_types\": [],\n  \"grant_types\": [\"refresh_token\"],\n  \"client_name\": \"My Example Client\",\n  \"token_endpoint_auth_method\": \"client_secret_basic\",\n  \"logo_uri\": \"https://client.example.org/logo.png\"\n}"
 								},
 								"url": {
 									"raw": "{{registrationEndpoint}}",
@@ -2263,13 +2582,11 @@
 											"    var body = pm.response.json();",
 											"    pm.expect(body).to.have.property('response_types');",
 											"    pm.expect(body).to.have.property('grant_types');",
-											"    pm.expect(body).to.have.property('scope');",
 											"    pm.expect(body).to.have.property('client_name');",
 											"    pm.expect(body).to.have.property('client_id');",
 											"    pm.expect(body).to.have.property('client_secret');",
 											"    pm.expect(body.response_types).to.eql(['code']);",
 											"    pm.expect(body.grant_types).to.eql(['authorization_code']);",
-											"    pm.expect(body.scope).to.eql('openid');",
 											"    pm.expect(body.client_name).to.eql('Unknown Client');",
 											"    ",
 											"    pm.environment.set('newClientForDCRTests', body.id);",
@@ -2398,6 +2715,56 @@
 								"body": {
 									"mode": "raw",
 									"raw": "{\n   \"client_name\": \"Should have not been updated\"\n}\n"
+								},
+								"url": {
+									"raw": "{{registrationClientUri}}",
+									"host": [
+										"{{registrationClientUri}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Invalid redirect uri - can not be empty",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
+										"exec": [
+											"pm.test(\"Status code is 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"Redirect uris are missing\", function () {",
+											"    pm.response.to.be.header('Content-Type', 'application/json');",
+											"    var body = pm.response.json();",
+											"    pm.expect(body.error).to.eql('invalid_redirect_uri');",
+											"    pm.expect(body.error_description).to.eql('Missing or invalid redirect_uris.');",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"type": "text",
+										"value": "Bearer {{registrationAccessToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n   \"client_name\": \"Client with implicit flow should not allow empty redirect_uris\",\n   \"grant_types\": [\"implicit\"],\n   \"response_types\": [\"token\"],\n   \"redirect_uris\": []\n}\n"
 								},
 								"url": {
 									"raw": "{{registrationClientUri}}",
@@ -2548,6 +2915,56 @@
 								"body": {
 									"mode": "raw",
 									"raw": "{\n  \"redirect_uris\": [\n    \"https://client.example.org/callback\",\n    \"https://client.example.org/callback2\"],\n  \"grant_types\": [\n\t\"unknown\"\n   ],\n   \"client_name\": \"Should have not been updated\"\n}"
+								},
+								"url": {
+									"raw": "{{registrationClientUri}}",
+									"host": [
+										"{{registrationClientUri}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Invalid grant type - refresh_token alone",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
+										"exec": [
+											"pm.test(\"Status code is 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"Invalid grant type\", function () {",
+											"    pm.response.to.be.header('Content-Type', 'application/json');",
+											"    var body = pm.response.json();",
+											"    pm.expect(body.error).to.eql('invalid_client_metadata');",
+											"    pm.expect(body.error_description).to.include('refresh_token grant type must be associated with one of');",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"type": "text",
+										"value": "Bearer {{registrationAccessToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"redirect_uris\": [],\n  \"response_types\": [],\n  \"grant_types\": [\"refresh_token\"],\n  \"client_name\": \"My Example Client\",\n  \"token_endpoint_auth_method\": \"client_secret_basic\",\n  \"logo_uri\": \"https://client.example.org/logo.png\"\n}"
 								},
 								"url": {
 									"raw": "{{registrationClientUri}}",
@@ -3061,342 +3478,628 @@
 			"name": "Case - Nominal",
 			"item": [
 				{
-					"name": "Register client",
-					"event": [
+					"name": "web application",
+					"item": [
 						{
-							"listen": "test",
-							"script": {
-								"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
-								"exec": [
-									"pm.test(\"Status code is 201\", function () {",
-									"    pm.response.to.have.status(201);",
-									"});",
-									"",
-									"pm.test(\"Has default attributes\", function () {",
-									"    var body = pm.response.json();",
-									"    pm.expect(body).to.have.property('response_types');",
-									"    pm.expect(body).to.have.property('grant_types');",
-									"    pm.expect(body).to.have.property('scope');",
-									"    pm.expect(body).to.have.property('client_name');",
-									"    pm.expect(body).to.have.property('client_id');",
-									"    pm.expect(body).to.have.property('client_secret');",
-									"    pm.expect(body.response_types).to.eql(['code']);",
-									"    pm.expect(body.grant_types).to.eql(['authorization_code']);",
-									"    pm.expect(body.scope).to.eql('openid');",
-									"    pm.expect(body.client_name).to.eql('Unknown Client');",
-									"    ",
-									"    pm.environment.set('newClientForDCRTests', body.id);",
-									"    pm.environment.set('registrationAccessToken', body.registration_access_token);",
-									"    pm.environment.set('registrationClientUri', body.registration_client_uri);",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "Authorization",
-								"type": "text",
-								"value": "Bearer {{access_token}}"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n   \"application_type\": \"web\",\n   \"redirect_uris\":\n     [\"https://client.example.org/callback\",\n      \"https://client.example.org/callback2\"],\n   \"logo_uri\": \"https://client.example.org/logo.png\",\n   \"subject_type\": \"public\",\n   \"token_endpoint_auth_method\": \"client_secret_basic\",\n   \"userinfo_encrypted_response_alg\": \"RSA-OAEP-256\",\n   \"userinfo_encrypted_response_enc\": \"A128CBC-HS256\",\n   \"contacts\": [\"ve7jtb@example.org\", \"mary@example.org\"],\n   \"request_uris\":\n     [\"https://client.example.org/rf.txt#qpXaRLh_n93TTR9F252ValdatUQvQiJi5BDub2BeznA\"]\n  }"
-						},
-						"url": {
-							"raw": "{{registrationEndpoint}}",
-							"host": [
-								"{{registrationEndpoint}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Patch client",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
-								"exec": [
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"pm.test(\"Patch client with response types\", function () {",
-									"    pm.response.to.be.header('Content-Type', 'application/json');",
-									"    var body = pm.response.json();",
-									"    pm.expect(body).to.have.property(\"responseTypes\");",
-									"    pm.expect(body).to.have.property(\"authorizedGrantTypes\");",
-									"    pm.expect(body.responseTypes).to.eql(['token', 'code', 'code token']);",
-									"    pm.expect(body.authorizedGrantTypes).to.eql([ 'implicit', 'authorization_code' ]);",
-									"});",
-									"",
-									"// wait for sync process",
-									"setTimeout(function(){}, 5000);"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "PATCH",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "Authorization",
-								"type": "text",
-								"value": "Bearer {{token}}"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n   \"responseTypes\": [\"token\", \"code\", \"code token\"],\n   \"clientName\": \"Client was created via DCR\"\n  }"
-						},
-						"url": {
-							"raw": "{{management_url}}/management/domains/{{domain}}/clients/{{newClientForDCRTests}}",
-							"host": [
-								"{{management_url}}"
+							"name": "Register client - web application",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"pm.test(\"Has default attributes\", function () {",
+											"    var body = pm.response.json();",
+											"    pm.expect(body).to.have.property('application_type');",
+											"    pm.expect(body).to.have.property('response_types');",
+											"    pm.expect(body).to.have.property('grant_types');",
+											"    pm.expect(body).to.have.property('client_name');",
+											"    pm.expect(body).to.have.property('client_id');",
+											"    pm.expect(body).to.have.property('client_secret');",
+											"    pm.expect(body.application_type).to.eql('web');",
+											"    pm.expect(body.response_types).to.eql(['code']);",
+											"    pm.expect(body.grant_types).to.eql(['authorization_code']);",
+											"    pm.expect(body.client_name).to.eql('Unknown Client');",
+											"    ",
+											"    pm.environment.set('newClientForDCRTests', body.id);",
+											"    pm.environment.set('registrationAccessToken', body.registration_access_token);",
+											"    pm.environment.set('registrationClientUri', body.registration_client_uri);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
 							],
-							"path": [
-								"management",
-								"domains",
-								"{{domain}}",
-								"clients",
-								"{{newClientForDCRTests}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get client - with registration token",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
-								"exec": [
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"pm.test(\"Get client with response types\", function () {",
-									"    pm.response.to.be.header('Content-Type', 'application/json');",
-									"    var body = pm.response.json();",
-									"    pm.expect(body).to.have.property(\"redirect_uris\");",
-									"    pm.expect(body).to.have.property(\"grant_types\");",
-									"    pm.expect(body.response_types).to.eql([ 'token','code','code token' ]);",
-									"    pm.expect(body.grant_types).to.eql([ 'implicit','authorization_code' ]);",
-									"    pm.expect(body.client_name).to.eql('Client was created via DCR');",
-									"    ",
-									"    //The Authorization Server need not include the registration_access_token or registration_client_uri value in this response unless they have been updated.",
-									"    pm.expect(body).to.not.have.property('registration_access_token');",
-									"    pm.expect(body).to.not.have.property('registration_client_uri');",
-									"});"
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"type": "text",
+										"value": "Bearer {{access_token}}"
+									}
 								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
+								"body": {
+									"mode": "raw",
+									"raw": "{\n   \"redirect_uris\":\n     [\"https://client.example.org/callback\",\n      \"https://client.example.org/callback2\"],\n   \"logo_uri\": \"https://client.example.org/logo.png\",\n   \"subject_type\": \"public\",\n   \"token_endpoint_auth_method\": \"client_secret_basic\",\n   \"userinfo_encrypted_response_alg\": \"RSA-OAEP-256\",\n   \"userinfo_encrypted_response_enc\": \"A128CBC-HS256\",\n   \"contacts\": [\"ve7jtb@example.org\", \"mary@example.org\"],\n   \"request_uris\":\n     [\"https://client.example.org/rf.txt#qpXaRLh_n93TTR9F252ValdatUQvQiJi5BDub2BeznA\"]\n  }"
+								},
+								"url": {
+									"raw": "{{registrationEndpoint}}",
+									"host": [
+										"{{registrationEndpoint}}"
+									]
+								}
 							},
-							{
-								"key": "Authorization",
-								"type": "text",
-								"value": "Bearer {{registrationAccessToken}}"
-							}
-						],
-						"url": {
-							"raw": "{{registrationClientUri}}",
-							"host": [
-								"{{registrationClientUri}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Patch client - with registration token",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
-								"exec": [
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"pm.test(\"Get client with response types\", function () {",
-									"    pm.response.to.be.header('Content-Type', 'application/json');",
-									"    var body = pm.response.json();",
-									"    pm.expect(body.client_name).to.eql('Client patched via DCR');",
-									"    pm.expect(body).to.have.property(\"response_types\");",
-									"    pm.expect(body.response_types).to.eql(['token', 'code', 'code id_token']);",
-									"});",
-									"",
-									"pm.test(\"One time Token\", function() {",
-									"    var body = pm.response.json();",
-									"    pm.expect(body).to.have.property('registration_access_token');",
-									"    pm.expect(body.registration_access_token).to.not.eql(pm.environment.get('registrationAccessToken'));",
-									"    pm.environment.set('registrationAccessToken', body.registration_access_token);",
-									"    pm.environment.set('registrationClientUri', body.registration_client_uri);",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "PATCH",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "Authorization",
-								"type": "text",
-								"value": "Bearer {{registrationAccessToken}}"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n   \"client_name\": \"Client patched via DCR\",\n   \"response_types\" : [\"token\", \"code\", \"code id_token\"]\n}"
+							"response": []
 						},
-						"url": {
-							"raw": "{{registrationClientUri}}",
-							"host": [
-								"{{registrationClientUri}}"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Update client - with registration token",
-					"event": [
 						{
-							"listen": "test",
-							"script": {
-								"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
-								"exec": [
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"pm.test(\"Get client with response types\", function () {",
-									"    pm.response.to.be.header('Content-Type', 'application/json');",
-									"    var body = pm.response.json();",
-									"    pm.expect(body.client_name).to.eql('Client name updated via DCR');",
-									"    pm.expect(body).to.have.property(\"response_types\");",
-									"    pm.expect(body.response_types).to.eql(['code']);",
-									"});",
-									"",
-									"pm.test(\"One time Token\", function() {",
-									"    var body = pm.response.json();",
-									"    pm.expect(body).to.have.property('registration_access_token');",
-									"    pm.expect(body.registration_access_token).to.not.eql(pm.environment.get('registrationAccessToken'));",
-									"    pm.environment.set('registrationAccessToken', body.registration_access_token);",
-									"    pm.environment.set('registrationClientUri', body.registration_client_uri);",
-									"});"
+							"name": "Get client - with registration token",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Get client with response types\", function () {",
+											"    pm.response.to.be.header('Content-Type', 'application/json');",
+											"    var body = pm.response.json();",
+											"    pm.expect(body).to.have.property(\"redirect_uris\");",
+											"    pm.expect(body).to.have.property(\"grant_types\");",
+											"    pm.expect(body.response_types).to.eql([ 'code' ]);",
+											"    pm.expect(body.grant_types).to.eql([ 'authorization_code' ]);",
+											"    pm.expect(body.client_name).to.eql('Unknown Client');",
+											"    ",
+											"    //The Authorization Server need not include the registration_access_token or registration_client_uri value in this response unless they have been updated.",
+											"    pm.expect(body).to.not.have.property('registration_access_token');",
+											"    pm.expect(body).to.not.have.property('registration_client_uri');",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"type": "text",
+										"value": "Bearer {{registrationAccessToken}}"
+									}
 								],
-								"type": "text/javascript"
-							}
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{registrationClientUri}}",
+									"host": [
+										"{{registrationClientUri}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Patch client - with registration token",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Get client with response types\", function () {",
+											"    pm.response.to.be.header('Content-Type', 'application/json');",
+											"    var body = pm.response.json();",
+											"    pm.expect(body.client_name).to.eql('Client patched via DCR');",
+											"    pm.expect(body).to.have.property(\"response_types\");",
+											"    pm.expect(body.response_types).to.eql(['token', 'code', 'code id_token']);",
+											"    pm.expect(body.grant_types).to.eql([ 'implicit','authorization_code' ]);",
+											"});",
+											"",
+											"pm.test(\"One time Token\", function() {",
+											"    var body = pm.response.json();",
+											"    pm.expect(body).to.have.property('registration_access_token');",
+											"    pm.expect(body.registration_access_token).to.not.eql(pm.environment.get('registrationAccessToken'));",
+											"    pm.environment.set('registrationAccessToken', body.registration_access_token);",
+											"    pm.environment.set('registrationClientUri', body.registration_client_uri);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"type": "text",
+										"value": "Bearer {{registrationAccessToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n   \"client_name\": \"Client patched via DCR\",\n   \"response_types\" : [\"token\", \"code\", \"code id_token\"]\n}"
+								},
+								"url": {
+									"raw": "{{registrationClientUri}}",
+									"host": [
+										"{{registrationClientUri}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Update client - with registration token",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Get client with response types\", function () {",
+											"    pm.response.to.be.header('Content-Type', 'application/json');",
+											"    var body = pm.response.json();",
+											"    pm.expect(body.client_name).to.eql('Client name updated via DCR');",
+											"    pm.expect(body).to.have.property(\"response_types\");",
+											"    pm.expect(body.response_types).to.eql(['code']);",
+											"});",
+											"",
+											"pm.test(\"One time Token\", function() {",
+											"    var body = pm.response.json();",
+											"    pm.expect(body).to.have.property('registration_access_token');",
+											"    pm.expect(body.registration_access_token).to.not.eql(pm.environment.get('registrationAccessToken'));",
+											"    pm.environment.set('registrationAccessToken', body.registration_access_token);",
+											"    pm.environment.set('registrationClientUri', body.registration_client_uri);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"type": "text",
+										"value": "Bearer {{registrationAccessToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"redirect_uris\": [\n        \"https://client.example.org/callback\",\n        \"https://client.example.org/callback2\"\n    ],\n    \"response_types\": [\n        \"code\"\n    ],\n    \"grant_types\": [\n        \"authorization_code\"\n    ],\n    \"application_type\": \"web\",\n    \"contacts\": [\n        \"marie@example.org\",\n        \"jeanne@example.org\"\n    ],\n\t\"client_name\": \"Client name updated via DCR\",\n    \"logo_uri\": \"https://client.example.org/logo.png\",\n    \"subject_type\": \"public\",\n    \"userinfo_encrypted_response_alg\": \"RSA-OAEP-256\",\n    \"userinfo_encrypted_response_enc\": \"A128CBC-HS256\",\n    \"token_endpoint_auth_method\": \"client_secret_basic\",\n    \"require_auth_time\": false,\n    \"request_uris\": [\n        \"https://client.example.org/rf.txt#qpXaRLh_n93TTR9F252ValdatUQvQiJi5BDub2BeznA\"\n    ],\n    \"scope\": \"openid\"\n}"
+								},
+								"url": {
+									"raw": "{{registrationClientUri}}",
+									"host": [
+										"{{registrationClientUri}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete client - with registration token",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
+										"exec": [
+											"pm.test(\"Status code is 204\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"type": "text",
+										"value": "Bearer {{registrationAccessToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{registrationClientUri}}",
+									"host": [
+										"{{registrationClientUri}}"
+									]
+								}
+							},
+							"response": []
 						}
 					],
-					"request": {
-						"method": "PUT",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "Authorization",
-								"type": "text",
-								"value": "Bearer {{registrationAccessToken}}"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"redirect_uris\": [\n        \"https://client.example.org/callback\",\n        \"https://client.example.org/callback2\"\n    ],\n    \"response_types\": [\n        \"code\"\n    ],\n    \"grant_types\": [\n        \"authorization_code\"\n    ],\n    \"application_type\": \"web\",\n    \"contacts\": [\n        \"marie@example.org\",\n        \"jeanne@example.org\"\n    ],\n\t\"client_name\": \"Client name updated via DCR\",\n    \"logo_uri\": \"https://client.example.org/logo.png\",\n    \"subject_type\": \"public\",\n    \"userinfo_encrypted_response_alg\": \"RSA-OAEP-256\",\n    \"userinfo_encrypted_response_enc\": \"A128CBC-HS256\",\n    \"token_endpoint_auth_method\": \"client_secret_basic\",\n    \"require_auth_time\": false,\n    \"request_uris\": [\n        \"https://client.example.org/rf.txt#qpXaRLh_n93TTR9F252ValdatUQvQiJi5BDub2BeznA\"\n    ],\n    \"scope\": \"openid\"\n}"
-						},
-						"url": {
-							"raw": "{{registrationClientUri}}",
-							"host": [
-								"{{registrationClientUri}}"
-							]
-						}
-					},
-					"response": []
+					"_postman_isSubFolder": true
 				},
 				{
-					"name": "Delete client - with registration token",
-					"event": [
+					"name": "client application",
+					"item": [
 						{
-							"listen": "test",
-							"script": {
-								"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
-								"exec": [
-									"pm.test(\"Status code is 204\", function () {",
-									"    pm.response.to.have.status(204);",
-									"});",
-									""
+							"name": "Register client - client application",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"pm.test(\"Has default attributes\", function () {",
+											"    var body = pm.response.json();",
+											"    pm.expect(body).to.have.property('application_type');",
+											"    pm.expect(body).to.have.property('response_types');",
+											"    pm.expect(body).to.have.property('grant_types');",
+											"    pm.expect(body).to.have.property('client_name');",
+											"    pm.expect(body).to.have.property('client_id');",
+											"    pm.expect(body).to.have.property('client_secret');",
+											"    pm.expect(body.response_types).to.eql([]);",
+											"    pm.expect(body.application_type).to.eql('server');",
+											"    pm.expect(body.grant_types).to.eql(['client_credentials']);",
+											"    pm.expect(body.client_name).to.eql('Unknown Client');",
+											"    ",
+											"    pm.environment.set('newClientForDCRTests', body.id);",
+											"    pm.environment.set('registrationAccessToken', body.registration_access_token);",
+											"    pm.environment.set('registrationClientUri', body.registration_client_uri);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"type": "text",
+										"value": "Bearer {{access_token}}"
+									}
 								],
-								"type": "text/javascript"
-							}
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"application_type\": \"server\",\n\t\"redirect_uris\": null,\n\t\"grant_types\": [\"client_credentials\"],\n\t\"response_types\": null\n}"
+								},
+								"url": {
+									"raw": "{{registrationEndpoint}}",
+									"host": [
+										"{{registrationEndpoint}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get client - with registration token",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Get client with response types\", function () {",
+											"    pm.response.to.be.header('Content-Type', 'application/json');",
+											"    var body = pm.response.json();",
+											"    pm.expect(body).to.have.property(\"grant_types\");",
+											"    pm.expect(body.response_types).to.eql([]);",
+											"    pm.expect(body.grant_types).to.eql([ 'client_credentials' ]);",
+											"    ",
+											"    //The Authorization Server need not include the registration_access_token or registration_client_uri value in this response unless they have been updated.",
+											"    pm.expect(body).to.not.have.property('registration_access_token');",
+											"    pm.expect(body).to.not.have.property('registration_client_uri');",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"type": "text",
+										"value": "Bearer {{registrationAccessToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{registrationClientUri}}",
+									"host": [
+										"{{registrationClientUri}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Patch client - invalidRedirectUri",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
+										"exec": [
+											"pm.test(\"Status code is 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"Redirect uris are missing\", function () {",
+											"    pm.response.to.be.header('Content-Type', 'application/json');",
+											"    var body = pm.response.json();",
+											"    pm.expect(body.error).to.eql('invalid_redirect_uri');",
+											"    pm.expect(body.error_description).to.eql('Missing or invalid redirect_uris.');",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"type": "text",
+										"value": "Bearer {{registrationAccessToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n   \"client_name\": \"Adding code or token response type means a redirect_uri will be required.\",\n   \"response_types\" : [\"token\", \"code\", \"code id_token\"]\n}"
+								},
+								"url": {
+									"raw": "{{registrationClientUri}}",
+									"host": [
+										"{{registrationClientUri}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Patch client - with registration token",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Get client with response types\", function () {",
+											"    pm.response.to.be.header('Content-Type', 'application/json');",
+											"    var body = pm.response.json();",
+											"    pm.expect(body).to.have.property(\"response_types\");",
+											"    pm.expect(body.response_types).to.eql(['token', 'code', 'code id_token']);",
+											"    pm.expect(body).to.have.property(\"grant_types\");",
+											"    pm.expect(body.grant_types).to.eql(['implicit', 'client_credentials', 'authorization_code']);",
+											"});",
+											"",
+											"pm.test(\"One time Token\", function() {",
+											"    var body = pm.response.json();",
+											"    pm.expect(body).to.have.property('registration_access_token');",
+											"    pm.expect(body.registration_access_token).to.not.eql(pm.environment.get('registrationAccessToken'));",
+											"    pm.environment.set('registrationAccessToken', body.registration_access_token);",
+											"    pm.environment.set('registrationClientUri', body.registration_client_uri);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"type": "text",
+										"value": "Bearer {{registrationAccessToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n   \"client_name\": \"Do not block even if we add code/implicit in addition to client_credentials\",\n   \"response_types\" : [\"token\", \"code\", \"code id_token\"],\n   \"redirect_uris\": [\"https://callback\"]\n}"
+								},
+								"url": {
+									"raw": "{{registrationClientUri}}",
+									"host": [
+										"{{registrationClientUri}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Update client - with registration token",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Get client with response types\", function () {",
+											"    pm.response.to.be.header('Content-Type', 'application/json');",
+											"    var body = pm.response.json();",
+											"    pm.expect(body.client_name).to.eql('Client name updated via DCR');",
+											"    pm.expect(body).to.have.property(\"response_types\");",
+											"    pm.expect(body.response_types).to.eql([]);",
+											"    pm.expect(body).to.have.property(\"grant_types\");",
+											"    pm.expect(body.grant_types).to.eql([\"client_credentials\"]);",
+											"});",
+											"",
+											"pm.test(\"One time Token\", function() {",
+											"    var body = pm.response.json();",
+											"    pm.expect(body).to.have.property('registration_access_token');",
+											"    pm.expect(body.registration_access_token).to.not.eql(pm.environment.get('registrationAccessToken'));",
+											"    pm.environment.set('registrationAccessToken', body.registration_access_token);",
+											"    pm.environment.set('registrationClientUri', body.registration_client_uri);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"type": "text",
+										"value": "Bearer {{registrationAccessToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"application_type\": \"server\",\n\t\"redirect_uris\": null,\n\t\"grant_types\": [\"client_credentials\"],\n\t\"response_types\": null,\n\t\n    \"contacts\": [\n        \"marie@example.org\",\n        \"jeanne@example.org\"\n    ],\n\t\"client_name\": \"Client name updated via DCR\",\n    \"logo_uri\": \"https://client.example.org/logo.png\",\n    \"subject_type\": \"public\",\n    \"token_endpoint_auth_method\": \"client_secret_basic\",\n    \"require_auth_time\": false,\n    \"request_uris\": [\n        \"https://client.example.org/rf.txt#qpXaRLh_n93TTR9F252ValdatUQvQiJi5BDub2BeznA\"\n    ]\n}"
+								},
+								"url": {
+									"raw": "{{registrationClientUri}}",
+									"host": [
+										"{{registrationClientUri}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete client - with registration token",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
+										"exec": [
+											"pm.test(\"Status code is 204\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"type": "text",
+										"value": "Bearer {{registrationAccessToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{registrationClientUri}}",
+									"host": [
+										"{{registrationClientUri}}"
+									]
+								}
+							},
+							"response": []
 						}
 					],
-					"request": {
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "Authorization",
-								"type": "text",
-								"value": "Bearer {{registrationAccessToken}}"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
-						"url": {
-							"raw": "{{registrationClientUri}}",
-							"host": [
-								"{{registrationClientUri}}"
-							]
-						}
-					},
-					"response": []
+					"_postman_isSubFolder": true
 				}
 			]
 		},
@@ -3404,7 +4107,7 @@
 			"name": "Case - Signing id_token",
 			"item": [
 				{
-					"name": "Generate token - client",
+					"name": "Generate token - Case signing id_token",
 					"event": [
 						{
 							"listen": "test",
@@ -3519,7 +4222,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"client_name\":\"client_rs256\",\n    \"application_type\": \"web\",\n    \"contacts\": [\"roland@example.com\"],\n    \"grant_types\": [\"authorization_code\",\"implicit\",\"password\"],\n    \"post_logout_redirect_uris\": [\"https://op-test:60001/logout\"],\n    \"redirect_uris\": [\"https://op-test:60001/authz_cb\"],\n    \"response_types\": [\"code\",\"token\",\"id_token\"],\n    \"token_endpoint_auth_method\": \"client_secret_basic\",\n    \"id_token_signed_response_alg\": \"RS256\"\n}"
+							"raw": "{\n\t\"client_name\":\"client_rs256\",\n    \"redirect_uris\": [\"https://op-test:60001/authz_cb\"],\n    \"application_type\": \"web\",\n    \"contacts\": [\"roland@example.com\"],\n    \"response_types\": [\"code\",\"token\",\"id_token\"],\n    \"grant_types\": [\"authorization_code\",\"implicit\",\"password\"],\n    \"scope\": \"openid\",\n    \"post_logout_redirect_uris\": [\"https://op-test:60001/logout\"],\n    \"token_endpoint_auth_method\": \"client_secret_basic\",\n    \"id_token_signed_response_alg\": \"RS256\"\n}"
 						},
 						"url": {
 							"raw": "{{registrationEndpoint}}",
@@ -3602,7 +4305,8 @@
 								{
 									"key": "scope",
 									"value": "openid",
-									"type": "text"
+									"type": "text",
+									"disabled": true
 								}
 							]
 						},
@@ -3922,7 +4626,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"client_name\": \"Client test for JWE - no jwks\",\n    \"application_type\": \"web\",\n    \"contacts\": [\"roland@example.com\"],\n    \"grant_types\": [\"authorization_code\",\"implicit\",\"password\"],\n    \"post_logout_redirect_uris\": [\"https://op-test:60001/logout\"],\n    \"redirect_uris\": [\"https://op-test:60001/authz_cb\"],\n    \"request_uris\": [\"https://op-test:60001/requests/4472f1ee2cd34273a9b8bff4be1549418e5dd1b182639b7b2ae21d93e387467e#hNN9dc7MUCrZF0Jq\"],\n    \"response_types\": [\"code\",\"id_token\"],\n    \"token_endpoint_auth_method\": \"private_key_jwt\",\n    \"id_token_encrypted_response_alg\": \"RSA-OAEP-256\"\n}"
+									"raw": "{\n\t\"client_name\": \"Client test for JWE - no jwks\",\n    \"application_type\": \"web\",\n    \"contacts\": [\"roland@example.com\"],\n    \"grant_types\": [\"authorization_code\",\"implicit\",\"password\"],\n    \"scope\": \"openid\",\n    \"post_logout_redirect_uris\": [\"https://op-test:60001/logout\"],\n    \"redirect_uris\": [\"https://op-test:60001/authz_cb\"],\n    \"request_uris\": [\"https://op-test:60001/requests/4472f1ee2cd34273a9b8bff4be1549418e5dd1b182639b7b2ae21d93e387467e#hNN9dc7MUCrZF0Jq\"],\n    \"response_types\": [\"code\",\"id_token\"],\n    \"token_endpoint_auth_method\": \"private_key_jwt\",\n    \"id_token_encrypted_response_alg\": \"RSA-OAEP-256\"\n}"
 								},
 								"url": {
 									"raw": "{{registrationEndpoint}}",
@@ -4101,7 +4805,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"client_name\": \"Client test for JWE - no jwks\",\n    \"application_type\": \"web\",\n    \"contacts\": [\"roland@example.com\"],\n    \"grant_types\": [\"authorization_code\",\"implicit\",\"password\"],\n    \"post_logout_redirect_uris\": [\"https://op-test:60001/logout\"],\n    \"redirect_uris\": [\"https://op-test:60001/authz_cb\"],\n    \"request_uris\": [\"https://op-test:60001/requests/4472f1ee2cd34273a9b8bff4be1549418e5dd1b182639b7b2ae21d93e387467e#hNN9dc7MUCrZF0Jq\"],\n    \"response_types\": [\"code\",\"id_token\"],\n    \"token_endpoint_auth_method\": \"private_key_jwt\",\n    \"jwks\": {\n        \"keys\": [\n\t\t\t{  \n\t\t\t\t\"kty\": \"RSA\",\n\t\t\t\t\"use\": \"enc\",\n\t\t\t\t\"kid\": \"rsa-encryption-256\",\n\t\t\t\t\"e\": \"AQAB\",\n\t\t\t\t\"n\": \"lFAsvOm58TV5q9zyb3psQSESezZtYLZryGjq8LMnuqRt9cdPQCvMrnjcqdFWiXkD4ZXRO2Wp1iyzgprecx3dAnaD-KHlZR7vsFEmDh27DgNvEx5jKRSy5N2quI2LJw66Jb9JeMqoX6vtv_z3PRHb-zUhnIw6tBwZtuNE-AZSC6atr8ZCLXn6RPqJq_eoGgG-xaAzWPyRXDIqWPVO0RD3odjs6er7BcqVyHg54DyylrmRI4m6xERxpuNYI57bQN5_7a_3tR7hLeHJ8J1mNraMLH7H5_aAM_oSqKBEG9jHSTR7JsI3gSvsNOG-nP9jYxw7fH_c1XfRuTEJfBPEZxzD2Q\"\n\t\t\t},\n            {\n                \"kty\": \"RSA\",\n                \"use\": \"sig\",\n                \"kid\": \"rsa-signature\",\n                \"e\": \"AQAB\",\n                \"n\": \"pRXXMvbZC4-I8nmeirMmr_wlo-lpZo2cyfXLPSduieEsfLeO38vIFdXbVTQ-OAeihFrvbxHELt2mNwCH3gbosd0P-pyYtUOaGmi7rLW9Wik8JcNCKA-v7q2JWmBeRFyRAuwf343gnxNL1mpUHfhqd4eswRiO55iwFT8a8gmxSOm8VXjg2aeUjkI3diT84rGR-wK77OcXeF2zJzjRDe0yFla0Tjb1RNTNkVQBJAQ3VQOOaNL7bXajR79ERlMKCjRFIZ0QCB7Nf6LtMwp9QWRdFrm7RXIPpN1V03E4v51gq82URjuQvEANe-VGRVSBij_GcOSLGjyZQi-yGVyPjNVl1Q\"\n            },\n            {\n                \"kty\": \"EC\",\n                \"use\": \"sig\",\n                \"crv\": \"P-256\",\n                \"kid\": \"elliptic-curve-signature\",\n                \"x\": \"R4JmPwezbzLuyGkonWIkezzplUfed5b6F5PL4j0zdf8\",\n                \"y\": \"QQRGKwRV9jHSlHjUhOQ0FqdQEddFBPCHZXpoFjvGmcY\"\n            },\n\t\t\t{  \n\t\t\t\t\"kty\":\"EC\",\n\t\t\t\t\"use\":\"enc\",\n\t\t\t\t\"crv\":\"P-521\",\n                \"kid\": \"elliptic-curve-encryption\",\n\t\t\t\t\"x\":\"AfEFyeYAr1TwmvCxvqgWPEg4Vvf50RC2OdkYfTS30dInZwX-Ebn6elp4fQ0GOdOBbYRq9b2gQ79Cd1AytQhdF6To\",\n\t\t\t\t\"y\":\"Abj0w4nSumQWtO6AV7ufQN6VpmJoKlWmz9KB6BUU0ANcj4aTJjBE9WNiGCqFpvaIdEWZWcSsZNYGKT3rJ71AfLdm\"\n\t\t\t},\n\t\t\t{  \n\t\t\t\t\"kty\":\"OKP\",\n\t\t\t\t\"use\":\"enc\",\n\t\t\t\t\"kid\":\"edwards-curve-encryption\",\n\t\t\t\t\"crv\":\"X25519\",\n\t\t\t\t\"x\":\"vBNW8f19leF79U4U6NrDDQaK_i5kL0iMKghB39AUT2I\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"kty\": \"oct\",\n\t\t\t\t\"kid\": \"128bits\",\n\t\t\t\t\"k\" : \"p94TA_PhiVUdi_yxPbviAw\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"kty\": \"oct\",\n\t\t\t\t\"kid\": \"192bits\",\n\t\t\t\t\"k\" : \"G9jUYv3b0-0wZWCGxAnIUH6gI0kjeXj4\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"kty\": \"oct\",\n\t\t\t\t\"kid\": \"256bits\",\n\t\t\t\t\"k\" : \"pzx01XDfexcfxHWtk_MzjfCin5NMy3KBx2xtjrX1G-E\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"kty\": \"oct\",\n\t\t\t\t\"kid\": \"384bits\",\n\t\t\t\t\"k\" : \"MBNrGN8nwS7hlOVfqEy6qA98bzyo1BLGxr-kyN1E4UXYWQDkBg4L7AQRwpZdrKKS\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"kty\": \"oct\",\n\t\t\t\t\"kid\": \"512bits\",\n\t\t\t\t\"k\" : \"LfWisS5p-ohMbNbeWdiSapnHgA62XPu8DXzyzNZQHtQPglHf0Lb6NUM-8aQGj_YWErvODY5rQkpKeolrBKkcmg\"\n\t\t\t}\n        ]\n    }\n}"
+									"raw": "{\n\t\"client_name\": \"Client test for JWE - no jwks\",\n    \"application_type\": \"web\",\n    \"contacts\": [\"roland@example.com\"],\n    \"grant_types\": [\"authorization_code\",\"implicit\",\"password\"],\n    \"scope\": \"openid\",\n    \"post_logout_redirect_uris\": [\"https://op-test:60001/logout\"],\n    \"redirect_uris\": [\"https://op-test:60001/authz_cb\"],\n    \"request_uris\": [\"https://op-test:60001/requests/4472f1ee2cd34273a9b8bff4be1549418e5dd1b182639b7b2ae21d93e387467e#hNN9dc7MUCrZF0Jq\"],\n    \"response_types\": [\"code\",\"id_token\"],\n    \"token_endpoint_auth_method\": \"private_key_jwt\",\n    \"jwks\": {\n        \"keys\": [\n\t\t\t{  \n\t\t\t\t\"kty\": \"RSA\",\n\t\t\t\t\"use\": \"enc\",\n\t\t\t\t\"kid\": \"rsa-encryption-256\",\n\t\t\t\t\"e\": \"AQAB\",\n\t\t\t\t\"n\": \"lFAsvOm58TV5q9zyb3psQSESezZtYLZryGjq8LMnuqRt9cdPQCvMrnjcqdFWiXkD4ZXRO2Wp1iyzgprecx3dAnaD-KHlZR7vsFEmDh27DgNvEx5jKRSy5N2quI2LJw66Jb9JeMqoX6vtv_z3PRHb-zUhnIw6tBwZtuNE-AZSC6atr8ZCLXn6RPqJq_eoGgG-xaAzWPyRXDIqWPVO0RD3odjs6er7BcqVyHg54DyylrmRI4m6xERxpuNYI57bQN5_7a_3tR7hLeHJ8J1mNraMLH7H5_aAM_oSqKBEG9jHSTR7JsI3gSvsNOG-nP9jYxw7fH_c1XfRuTEJfBPEZxzD2Q\"\n\t\t\t},\n            {\n                \"kty\": \"RSA\",\n                \"use\": \"sig\",\n                \"kid\": \"rsa-signature\",\n                \"e\": \"AQAB\",\n                \"n\": \"pRXXMvbZC4-I8nmeirMmr_wlo-lpZo2cyfXLPSduieEsfLeO38vIFdXbVTQ-OAeihFrvbxHELt2mNwCH3gbosd0P-pyYtUOaGmi7rLW9Wik8JcNCKA-v7q2JWmBeRFyRAuwf343gnxNL1mpUHfhqd4eswRiO55iwFT8a8gmxSOm8VXjg2aeUjkI3diT84rGR-wK77OcXeF2zJzjRDe0yFla0Tjb1RNTNkVQBJAQ3VQOOaNL7bXajR79ERlMKCjRFIZ0QCB7Nf6LtMwp9QWRdFrm7RXIPpN1V03E4v51gq82URjuQvEANe-VGRVSBij_GcOSLGjyZQi-yGVyPjNVl1Q\"\n            },\n            {\n                \"kty\": \"EC\",\n                \"use\": \"sig\",\n                \"crv\": \"P-256\",\n                \"kid\": \"elliptic-curve-signature\",\n                \"x\": \"R4JmPwezbzLuyGkonWIkezzplUfed5b6F5PL4j0zdf8\",\n                \"y\": \"QQRGKwRV9jHSlHjUhOQ0FqdQEddFBPCHZXpoFjvGmcY\"\n            },\n\t\t\t{  \n\t\t\t\t\"kty\":\"EC\",\n\t\t\t\t\"use\":\"enc\",\n\t\t\t\t\"crv\":\"P-521\",\n                \"kid\": \"elliptic-curve-encryption\",\n\t\t\t\t\"x\":\"AfEFyeYAr1TwmvCxvqgWPEg4Vvf50RC2OdkYfTS30dInZwX-Ebn6elp4fQ0GOdOBbYRq9b2gQ79Cd1AytQhdF6To\",\n\t\t\t\t\"y\":\"Abj0w4nSumQWtO6AV7ufQN6VpmJoKlWmz9KB6BUU0ANcj4aTJjBE9WNiGCqFpvaIdEWZWcSsZNYGKT3rJ71AfLdm\"\n\t\t\t},\n\t\t\t{  \n\t\t\t\t\"kty\":\"OKP\",\n\t\t\t\t\"use\":\"enc\",\n\t\t\t\t\"kid\":\"edwards-curve-encryption\",\n\t\t\t\t\"crv\":\"X25519\",\n\t\t\t\t\"x\":\"vBNW8f19leF79U4U6NrDDQaK_i5kL0iMKghB39AUT2I\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"kty\": \"oct\",\n\t\t\t\t\"kid\": \"128bits\",\n\t\t\t\t\"k\" : \"p94TA_PhiVUdi_yxPbviAw\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"kty\": \"oct\",\n\t\t\t\t\"kid\": \"192bits\",\n\t\t\t\t\"k\" : \"G9jUYv3b0-0wZWCGxAnIUH6gI0kjeXj4\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"kty\": \"oct\",\n\t\t\t\t\"kid\": \"256bits\",\n\t\t\t\t\"k\" : \"pzx01XDfexcfxHWtk_MzjfCin5NMy3KBx2xtjrX1G-E\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"kty\": \"oct\",\n\t\t\t\t\"kid\": \"384bits\",\n\t\t\t\t\"k\" : \"MBNrGN8nwS7hlOVfqEy6qA98bzyo1BLGxr-kyN1E4UXYWQDkBg4L7AQRwpZdrKKS\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"kty\": \"oct\",\n\t\t\t\t\"kid\": \"512bits\",\n\t\t\t\t\"k\" : \"LfWisS5p-ohMbNbeWdiSapnHgA62XPu8DXzyzNZQHtQPglHf0Lb6NUM-8aQGj_YWErvODY5rQkpKeolrBKkcmg\"\n\t\t\t}\n        ]\n    }\n}"
 								},
 								"url": {
 									"raw": "{{registrationEndpoint}}",
@@ -21089,7 +21793,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"client_name\":\"client_rs384\",\n    \"application_type\": \"web\",\n    \"contacts\": [\"roland@example.com\"],\n    \"grant_types\": [\"authorization_code\",\"implicit\",\"password\"],\n    \"post_logout_redirect_uris\": [\"https://op-test:60001/logout\"],\n    \"redirect_uris\": [\"https://op-test:60001/authz_cb\"],\n    \"response_types\": [\"code\",\"token\"],\n    \"token_endpoint_auth_method\": \"client_secret_basic\",\n    \"userinfo_signed_response_alg\": \"RS384\"\n}"
+							"raw": "{\n\t\"client_name\":\"client_rs384\",\n    \"application_type\": \"web\",\n    \"contacts\": [\"roland@example.com\"],\n    \"grant_types\": [\"authorization_code\",\"implicit\",\"password\"],\n    \"scope\": \"openid\",\n    \"post_logout_redirect_uris\": [\"https://op-test:60001/logout\"],\n    \"redirect_uris\": [\"https://op-test:60001/authz_cb\"],\n    \"response_types\": [\"code\",\"token\"],\n    \"token_endpoint_auth_method\": \"client_secret_basic\",\n    \"userinfo_signed_response_alg\": \"RS384\"\n}"
 						},
 						"url": {
 							"raw": "{{registrationEndpoint}}",
@@ -21233,6 +21937,10 @@
 								"value": "Bearer {{access_token}}"
 							}
 						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
 						"url": {
 							"raw": "{{userinfoEndpoint}}",
 							"host": [
@@ -21451,6 +22159,10 @@
 								"value": "Bearer {{access_token}}"
 							}
 						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
 						"url": {
 							"raw": "{{userinfoEndpoint}}",
 							"host": [
@@ -21717,7 +22429,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"client_name\": \"Client test for JWE - no jwks\",\n    \"application_type\": \"web\",\n    \"contacts\": [\"roland@example.com\"],\n    \"grant_types\": [\"password\"],\n    \"post_logout_redirect_uris\": [\"https://op-test:60001/logout\"],\n    \"redirect_uris\": [\"https://op-test:60001/authz_cb\"],\n    \"request_uris\": [\"https://op-test:60001/requests/4472f1ee2cd34273a9b8bff4be1549418e5dd1b182639b7b2ae21d93e387467e#hNN9dc7MUCrZF0Jq\"],\n    \"token_endpoint_auth_method\": \"private_key_jwt\",\n    \"userinfo_encrypted_response_alg\": \"RSA-OAEP-256\"\n}"
+									"raw": "{\n\t\"client_name\": \"Client test for JWE - no jwks\",\n    \"application_type\": \"web\",\n    \"contacts\": [\"roland@example.com\"],\n    \"grant_types\": [\"password\"],\n    \"scope\": \"openid\",\n    \"post_logout_redirect_uris\": [\"https://op-test:60001/logout\"],\n    \"redirect_uris\": [\"https://op-test:60001/authz_cb\"],\n    \"request_uris\": [\"https://op-test:60001/requests/4472f1ee2cd34273a9b8bff4be1549418e5dd1b182639b7b2ae21d93e387467e#hNN9dc7MUCrZF0Jq\"],\n    \"token_endpoint_auth_method\": \"private_key_jwt\",\n    \"userinfo_encrypted_response_alg\": \"RSA-OAEP-256\"\n}"
 								},
 								"url": {
 									"raw": "{{registrationEndpoint}}",
@@ -22056,7 +22768,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"client_name\": \"Client test for JWE - no jwks\",\n    \"application_type\": \"web\",\n    \"contacts\": [\"roland@example.com\"],\n    \"grant_types\": [\"password\"],\n    \"post_logout_redirect_uris\": [\"https://op-test:60001/logout\"],\n    \"redirect_uris\": [\"https://op-test:60001/authz_cb\"],\n    \"request_uris\": [\"https://op-test:60001/requests/4472f1ee2cd34273a9b8bff4be1549418e5dd1b182639b7b2ae21d93e387467e#hNN9dc7MUCrZF0Jq\"],\n    \"token_endpoint_auth_method\": \"private_key_jwt\",\n    \"jwks\": {\n        \"keys\": [\n\t\t\t{  \n\t\t\t\t\"kty\": \"RSA\",\n\t\t\t\t\"use\": \"enc\",\n\t\t\t\t\"kid\": \"rsa-encryption-256\",\n\t\t\t\t\"e\": \"AQAB\",\n\t\t\t\t\"n\": \"lFAsvOm58TV5q9zyb3psQSESezZtYLZryGjq8LMnuqRt9cdPQCvMrnjcqdFWiXkD4ZXRO2Wp1iyzgprecx3dAnaD-KHlZR7vsFEmDh27DgNvEx5jKRSy5N2quI2LJw66Jb9JeMqoX6vtv_z3PRHb-zUhnIw6tBwZtuNE-AZSC6atr8ZCLXn6RPqJq_eoGgG-xaAzWPyRXDIqWPVO0RD3odjs6er7BcqVyHg54DyylrmRI4m6xERxpuNYI57bQN5_7a_3tR7hLeHJ8J1mNraMLH7H5_aAM_oSqKBEG9jHSTR7JsI3gSvsNOG-nP9jYxw7fH_c1XfRuTEJfBPEZxzD2Q\"\n\t\t\t},\n            {\n                \"kty\": \"RSA\",\n                \"use\": \"sig\",\n                \"kid\": \"rsa-signature\",\n                \"e\": \"AQAB\",\n                \"n\": \"pRXXMvbZC4-I8nmeirMmr_wlo-lpZo2cyfXLPSduieEsfLeO38vIFdXbVTQ-OAeihFrvbxHELt2mNwCH3gbosd0P-pyYtUOaGmi7rLW9Wik8JcNCKA-v7q2JWmBeRFyRAuwf343gnxNL1mpUHfhqd4eswRiO55iwFT8a8gmxSOm8VXjg2aeUjkI3diT84rGR-wK77OcXeF2zJzjRDe0yFla0Tjb1RNTNkVQBJAQ3VQOOaNL7bXajR79ERlMKCjRFIZ0QCB7Nf6LtMwp9QWRdFrm7RXIPpN1V03E4v51gq82URjuQvEANe-VGRVSBij_GcOSLGjyZQi-yGVyPjNVl1Q\"\n            },\n            {\n                \"kty\": \"EC\",\n                \"use\": \"sig\",\n                \"crv\": \"P-256\",\n                \"kid\": \"elliptic-curve-signature\",\n                \"x\": \"R4JmPwezbzLuyGkonWIkezzplUfed5b6F5PL4j0zdf8\",\n                \"y\": \"QQRGKwRV9jHSlHjUhOQ0FqdQEddFBPCHZXpoFjvGmcY\"\n            },\n\t\t\t{  \n\t\t\t\t\"kty\":\"EC\",\n\t\t\t\t\"use\":\"enc\",\n\t\t\t\t\"crv\":\"P-521\",\n                \"kid\": \"elliptic-curve-encryption\",\n\t\t\t\t\"x\":\"AfEFyeYAr1TwmvCxvqgWPEg4Vvf50RC2OdkYfTS30dInZwX-Ebn6elp4fQ0GOdOBbYRq9b2gQ79Cd1AytQhdF6To\",\n\t\t\t\t\"y\":\"Abj0w4nSumQWtO6AV7ufQN6VpmJoKlWmz9KB6BUU0ANcj4aTJjBE9WNiGCqFpvaIdEWZWcSsZNYGKT3rJ71AfLdm\"\n\t\t\t},\n\t\t\t{  \n\t\t\t\t\"kty\":\"OKP\",\n\t\t\t\t\"use\":\"enc\",\n\t\t\t\t\"kid\":\"edwards-curve-encryption\",\n\t\t\t\t\"crv\":\"X25519\",\n\t\t\t\t\"x\":\"vBNW8f19leF79U4U6NrDDQaK_i5kL0iMKghB39AUT2I\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"kty\": \"oct\",\n\t\t\t\t\"kid\": \"128bits\",\n\t\t\t\t\"k\" : \"p94TA_PhiVUdi_yxPbviAw\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"kty\": \"oct\",\n\t\t\t\t\"kid\": \"192bits\",\n\t\t\t\t\"k\" : \"G9jUYv3b0-0wZWCGxAnIUH6gI0kjeXj4\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"kty\": \"oct\",\n\t\t\t\t\"kid\": \"256bits\",\n\t\t\t\t\"k\" : \"pzx01XDfexcfxHWtk_MzjfCin5NMy3KBx2xtjrX1G-E\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"kty\": \"oct\",\n\t\t\t\t\"kid\": \"384bits\",\n\t\t\t\t\"k\" : \"MBNrGN8nwS7hlOVfqEy6qA98bzyo1BLGxr-kyN1E4UXYWQDkBg4L7AQRwpZdrKKS\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"kty\": \"oct\",\n\t\t\t\t\"kid\": \"512bits\",\n\t\t\t\t\"k\" : \"LfWisS5p-ohMbNbeWdiSapnHgA62XPu8DXzyzNZQHtQPglHf0Lb6NUM-8aQGj_YWErvODY5rQkpKeolrBKkcmg\"\n\t\t\t}\n        ]\n    }\n}"
+									"raw": "{\n\t\"client_name\": \"Client test for JWE - no jwks\",\n    \"application_type\": \"web\",\n    \"contacts\": [\"roland@example.com\"],\n    \"grant_types\": [\"password\"],\n    \"scope\": \"openid\",\n    \"post_logout_redirect_uris\": [\"https://op-test:60001/logout\"],\n    \"redirect_uris\": [\"https://op-test:60001/authz_cb\"],\n    \"request_uris\": [\"https://op-test:60001/requests/4472f1ee2cd34273a9b8bff4be1549418e5dd1b182639b7b2ae21d93e387467e#hNN9dc7MUCrZF0Jq\"],\n    \"token_endpoint_auth_method\": \"private_key_jwt\",\n    \"jwks\": {\n        \"keys\": [\n\t\t\t{  \n\t\t\t\t\"kty\": \"RSA\",\n\t\t\t\t\"use\": \"enc\",\n\t\t\t\t\"kid\": \"rsa-encryption-256\",\n\t\t\t\t\"e\": \"AQAB\",\n\t\t\t\t\"n\": \"lFAsvOm58TV5q9zyb3psQSESezZtYLZryGjq8LMnuqRt9cdPQCvMrnjcqdFWiXkD4ZXRO2Wp1iyzgprecx3dAnaD-KHlZR7vsFEmDh27DgNvEx5jKRSy5N2quI2LJw66Jb9JeMqoX6vtv_z3PRHb-zUhnIw6tBwZtuNE-AZSC6atr8ZCLXn6RPqJq_eoGgG-xaAzWPyRXDIqWPVO0RD3odjs6er7BcqVyHg54DyylrmRI4m6xERxpuNYI57bQN5_7a_3tR7hLeHJ8J1mNraMLH7H5_aAM_oSqKBEG9jHSTR7JsI3gSvsNOG-nP9jYxw7fH_c1XfRuTEJfBPEZxzD2Q\"\n\t\t\t},\n            {\n                \"kty\": \"RSA\",\n                \"use\": \"sig\",\n                \"kid\": \"rsa-signature\",\n                \"e\": \"AQAB\",\n                \"n\": \"pRXXMvbZC4-I8nmeirMmr_wlo-lpZo2cyfXLPSduieEsfLeO38vIFdXbVTQ-OAeihFrvbxHELt2mNwCH3gbosd0P-pyYtUOaGmi7rLW9Wik8JcNCKA-v7q2JWmBeRFyRAuwf343gnxNL1mpUHfhqd4eswRiO55iwFT8a8gmxSOm8VXjg2aeUjkI3diT84rGR-wK77OcXeF2zJzjRDe0yFla0Tjb1RNTNkVQBJAQ3VQOOaNL7bXajR79ERlMKCjRFIZ0QCB7Nf6LtMwp9QWRdFrm7RXIPpN1V03E4v51gq82URjuQvEANe-VGRVSBij_GcOSLGjyZQi-yGVyPjNVl1Q\"\n            },\n            {\n                \"kty\": \"EC\",\n                \"use\": \"sig\",\n                \"crv\": \"P-256\",\n                \"kid\": \"elliptic-curve-signature\",\n                \"x\": \"R4JmPwezbzLuyGkonWIkezzplUfed5b6F5PL4j0zdf8\",\n                \"y\": \"QQRGKwRV9jHSlHjUhOQ0FqdQEddFBPCHZXpoFjvGmcY\"\n            },\n\t\t\t{  \n\t\t\t\t\"kty\":\"EC\",\n\t\t\t\t\"use\":\"enc\",\n\t\t\t\t\"crv\":\"P-521\",\n                \"kid\": \"elliptic-curve-encryption\",\n\t\t\t\t\"x\":\"AfEFyeYAr1TwmvCxvqgWPEg4Vvf50RC2OdkYfTS30dInZwX-Ebn6elp4fQ0GOdOBbYRq9b2gQ79Cd1AytQhdF6To\",\n\t\t\t\t\"y\":\"Abj0w4nSumQWtO6AV7ufQN6VpmJoKlWmz9KB6BUU0ANcj4aTJjBE9WNiGCqFpvaIdEWZWcSsZNYGKT3rJ71AfLdm\"\n\t\t\t},\n\t\t\t{  \n\t\t\t\t\"kty\":\"OKP\",\n\t\t\t\t\"use\":\"enc\",\n\t\t\t\t\"kid\":\"edwards-curve-encryption\",\n\t\t\t\t\"crv\":\"X25519\",\n\t\t\t\t\"x\":\"vBNW8f19leF79U4U6NrDDQaK_i5kL0iMKghB39AUT2I\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"kty\": \"oct\",\n\t\t\t\t\"kid\": \"128bits\",\n\t\t\t\t\"k\" : \"p94TA_PhiVUdi_yxPbviAw\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"kty\": \"oct\",\n\t\t\t\t\"kid\": \"192bits\",\n\t\t\t\t\"k\" : \"G9jUYv3b0-0wZWCGxAnIUH6gI0kjeXj4\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"kty\": \"oct\",\n\t\t\t\t\"kid\": \"256bits\",\n\t\t\t\t\"k\" : \"pzx01XDfexcfxHWtk_MzjfCin5NMy3KBx2xtjrX1G-E\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"kty\": \"oct\",\n\t\t\t\t\"kid\": \"384bits\",\n\t\t\t\t\"k\" : \"MBNrGN8nwS7hlOVfqEy6qA98bzyo1BLGxr-kyN1E4UXYWQDkBg4L7AQRwpZdrKKS\"\n\t\t\t},\n\t\t\t{\n\t\t\t\t\"kty\": \"oct\",\n\t\t\t\t\"kid\": \"512bits\",\n\t\t\t\t\"k\" : \"LfWisS5p-ohMbNbeWdiSapnHgA62XPu8DXzyzNZQHtQPglHf0Lb6NUM-8aQGj_YWErvODY5rQkpKeolrBKkcmg\"\n\t\t\t}\n        ]\n    }\n}"
 								},
 								"url": {
 									"raw": "{{registrationEndpoint}}",

--- a/postman/collections/graviteeio-am-openid-discovery-collection.json
+++ b/postman/collections/graviteeio-am-openid-discovery-collection.json
@@ -120,62 +120,6 @@
 					"response": []
 				},
 				{
-					"name": "Create jks certificate rs256",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "a1ab79e9-b254-47f9-8af9-e6ab3e47ab58",
-								"exec": [
-									"pm.test(\"Status code is 201\", function () {",
-									"    pm.response.to.have.status(201);",
-									"});",
-									"",
-									"pm.test(\"Extension Grant - create jks certificate\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData).to.have.property('id');",
-									"    pm.environment.set('certificateJks', jsonData.id);",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Authorization",
-								"type": "text",
-								"value": "Bearer {{token}}"
-							},
-							{
-								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"type\": \"javakeystore-am-certificate\",\n  \"configuration\": \"{\\\"jks\\\":\\\"{\\\\\\\"name\\\\\\\":\\\\\\\"server.jks\\\\\\\",\\\\\\\"type\\\\\\\":\\\\\\\"\\\\\\\",\\\\\\\"size\\\\\\\":2237,\\\\\\\"content\\\\\\\":\\\\\\\"/u3+7QAAAAIAAAABAAAAAQAJbXl0ZXN0a2V5AAABYkPPuJkAAAUCMIIE/jAOBgorBgEEASoCEQEBBQAEggTqr5aJvYjZG/WQ8gGjoB2IzOwULJfXRbSwn0H9SP6vXE7TkFdVC6e7jOsPwwUVKwiTRCrNLL3G9OYyBvQEJv1NdPGYpqrD+4bzr5oVKQbwuXAs455phdjZ5jFlGjjowHBU7loxm5TJDncBfYoffptiStRSjzuuEWRPaRnUtL1PMidp4XdSOxzknBQ86zLz266y6pksmrSyCGxXiZwvnzq2TRvZOAT5haYA1wJOZwXAE4xk00C9Zr5NBIgyAZ0fsuZfquLhxpEgDg8XFsXAL7O4U9ocETktH4j5JnYWng6A90Ke2l4CUKjPvXTMYQr2ll26BjpE/TGyXRMNqqSzZ6tujn9wji1stGUS840AFye/HfZyQlkZBV/CyyDx/OkP0D9U5xO5jCnurGrMrbskIqcLchyb9xobr/RbnrpwMnK2XteCX9WRog064uYY8r722c81jFM6pL9Ue/Jm6h5fkHKZdJPJtMqdZf9fgb8VbxranRQDd3EIxx0yIXBddv6lqWMISXJCAni3MpBwiUAgzDdVVQYJlzu8t1x8cEpIrqD0sNQhGKmmDWwAE2mKJrYLaqaICKG9YaWy65ZPUOdQMUFzYOxpjNAvbDE/ZUs2jU1AbBpCk0HpgoBYckx0bIAN0buwaPUMwBgCzOjaQ6EQkNiORJoBdxqgI2GsN4j3TzUFSUIRZlFRxbn/f1Oo9SSznIfSzMRDEfoZYdLzwm01yBl5VwmCY5azrPGtAl+hmgBOdYM4O+svGTam+E4Iw2abX9T+B1im8ip4fEtn98Pgr//d+1cbYC2kcPMadfjMbp3d62z4DH9ABqTnEHBbfo1GgOpzpMRaKfrKvPap3PniP0YYqwDRJ4zn7OfYmrxVy8MENqGLveIksyvRj1K8Y3uexxZQ6CMAWbUuONJHHfBoTYsK+LdYxl7fCSuxqx9z0V3x5R3PCXchxNqR9f2tU1uDBqlXDESko0g9X0Qi1pLMk8A7wE5g8mChFhhrakrRMauwH0JkyLw+vcVpLqsyxsAcIm5bX3IWivPrbLZRW3lSLofdXj0XEuP2vnxdC82UPI3VQqqAI1UzL9sUl/cqhNGNztyRYAEv3FWttW2YTA1dlgq4DjPIRFAS4HyzgHeg8Jcgg/kRHbaLT4j2JVdqFG22CL+bayA6KqWeHos2bAA3ydw34y3QtJ0cqcH3iUZ0R0z++rG6iwDKPMkNW4osWP51UcFLXY/uNGSoverCQGJsD+wKvyi9KGDCsdjacgZJJtAsyOCxQssIPeB3GWt0rJi86SUqg0praNBXHKcbx5wSvp9i6uuaZhPzcvECPW/kgzPRaZLfneEZI+UPy31/jP8EUfQ9JT2hQ7w69jgVDE0WFhmNt8I/VrCMxFwCqYvA4m8xLmplZhCy+HUbLJMcwAx0yzbvH63kwcOASJC5JrnK0/P7UOc2NdAgXO/WrCZssRresxRNKaZvJTJtTrhElJKP9yD1zjiS4L5/PpGIW5md/qKX91zz0k5AzCqHdhBaRx7K7QVeWVEN8u4ZySbj9vCTLs1jTPcX7YpsPJBRGvqA4j9AYcBLzmhQa1huLVZTANE6j+vkgPvgPq4ToyTMKvUJwLbmIobX0ZyQKPGhe3LVorfM4uaSxq8+jMV4+0uddFNpLm9eJG+ZLbeVlu0157q45lxuQrO1VOvVLdqsrwAAAAEABVguNTA5AAADcTCCA20wggJVoAMCAQICBBCfcKYwDQYJKoZIhvcNAQELBQAwZzELMAkGA1UEBhMCVVMxDjAMBgNVBAgTBVN0YXRlMQ0wCwYDVQQHEwRDaXR5MRUwEwYDVQQKEwxPcmdhbml6YXRpb24xDTALBgNVBAsTBFVuaXQxEzARBgNVBAMTCldlYiBTZXJ2ZXIwHhcNMTgwMzIwMTQyODI5WhcNMTgwNjE4MTQyODI5WjBnMQswCQYDVQQGEwJVUzEOMAwGA1UECBMFU3RhdGUxDTALBgNVBAcTBENpdHkxFTATBgNVBAoTDE9yZ2FuaXphdGlvbjENMAsGA1UECxMEVW5pdDETMBEGA1UEAxMKV2ViIFNlcnZlcjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKu+JWbf4oP3xTz33EgXnD0jgL/clO/9lV25GFwygaR8F7qzPaknaR/psyO1acRv3UfrcYdZ2/nnh7PcchjEFmxh11pT3di2KquxsIJBzcYyYUHXbRaBRZ+Oqy884xzPc/IXLfLD5csCI0PQ+XaW/wrp6Mm9/CZNGHLUMjk9Aa9FbPnsh2gLGNkTwf4uvv11z94WFy7oWSzFra26C/zq3I7fywD2/UvYIJCOypAvxOcwdsNXxqEYroBu/jcoyMdXq2AWE6EdzVrZhpgK0QjTIoofa3QreGsdHBR+Cq7hDnGpakGQQVfTlhbzKCtaK9d8PAaOpwzKIcRiVG8NytE/QmECAwEAAaMhMB8wHQYDVR0OBBYEFJTE/I9yfWZ8smIobMkV2dtfpdFhMA0GCSqGSIb3DQEBCwUAA4IBAQCqZhd8O5GUUw1uX6jQKLjqjfzt7dPKMhNSUKPLrBktiJa+ZM/M+mGnEH6/TYcwzazAfeV+JgbY1KpMq1UVOW6KdDga2yXj43mVz7yzVB3KPIdMGSI4pqZxptQ7LEGVtSDsgqpQPi3qpsWUMLMW6heOHKc66Bdf9RE0S1ds+yMg9dNQBkTEXJKR6S+koyDcGnrZgwwVJ5T5+5ZUiGxe2wdGs7DUQCdDVwRZwkWzdIXPnK98PwFh7ivYI6+tnV+AHZg02IDAZ49rwNtQsExeQepNh2IPwCe+7TlfZ8TeiwcxL2ngqKA9LFP2do8YDz9XZbfl9AfS3GXeZsq3ihR3nffqT6271mTSYWrugh9IagHGV2PT6mo=\\\\\\\"}\\\",\\\"storepass\\\":\\\"letmein\\\",\\\"alias\\\":\\\"mytestkey\\\",\\\"keypass\\\":\\\"changeme\\\"}\",\n  \"name\": \"Test\"\n}"
-						},
-						"url": {
-							"raw": "{{management_url}}/management/domains/{{domain}}/certificates",
-							"host": [
-								"{{management_url}}"
-							],
-							"path": [
-								"management",
-								"domains",
-								"{{domain}}",
-								"certificates"
-							]
-						}
-					},
-					"response": []
-				},
-				{
 					"name": "Create jks certificate rs512",
 					"event": [
 						{


### PR DESCRIPTION
In order to run NRT, you must merge this [PR](https://github.com/gravitee-io/graviteeio-access-management/pull/592) before.

This fix issue [#2297](https://github.com/gravitee-io/issues/issues/2297)

Set redirect_uri as mandatory in the UI when grant_type require it
Set redirect_uris as not mandatory in DCR when grant_type does not require it
Remove default openid scope in DCR
Forbid selection of refresh_token grant when not necessary (DCR & UI)
Discovery grant & response types values are now delivered through Utils services
Add device_code grant (but not into the supported grant)
Some UI documentation improvements