### PR TITLE
Implement default & allowed scopes on DCR

### DIFF
--- a/docker/management-ui/run.sh
+++ b/docker/management-ui/run.sh
@@ -1,4 +1,19 @@
 #!/bin/sh
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 # generate configs
 /bin/confd -onetime -backend env

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/clientregistration/DynamicClientRegistrationRequest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/clientregistration/DynamicClientRegistrationRequest.java
@@ -25,6 +25,7 @@ import io.gravitee.am.model.oidc.JWKSet;
 import io.gravitee.am.service.utils.SetterUtils;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -397,7 +398,10 @@ public class DynamicClientRegistrationRequest {
 
     public Optional<List<String>> getScope() {
         if (this.scope == null) return null; //Keep null to avoid patch...
-        return Optional.of(Arrays.asList(scope.orElse("").split(SCOPE_DELIMITER)));
+        if (!this.scope.isPresent() || this.scope.get().trim().isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(Arrays.asList(scope.get().split(SCOPE_DELIMITER)));
     }
 
     public void setScope(Optional<String> scope) {
@@ -436,9 +440,9 @@ public class DynamicClientRegistrationRequest {
     public Client patch(Client client) {
         /* set openid request metadata */
         SetterUtils.safeSet(client::setRedirectUris, this.getRedirectUris());
-        SetterUtils.safeSetOrElse(client::setResponseTypes, this.getResponseTypes(), Client.DEFAULT_RESPONSE_TYPES);
-        SetterUtils.safeSetOrElse(client::setAuthorizedGrantTypes, this.getGrantTypes(), Client.DEFAULT_GRANT_TYPES);
-        SetterUtils.safeSetOrElse(client::setApplicationType, this.getApplicationType(), ApplicationType.WEB);
+        SetterUtils.safeSet(client::setResponseTypes, this.getResponseTypes());
+        SetterUtils.safeSet(client::setAuthorizedGrantTypes, this.getGrantTypes());
+        SetterUtils.safeSet(client::setApplicationType, this.getApplicationType());
         SetterUtils.safeSet(client::setContacts, this.getContacts());
         SetterUtils.safeSet(client::setClientName, this.getClientName());
         SetterUtils.safeSet(client::setLogoUri, this.getLogoUri());

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/discovery/OpenIDProviderMetadata.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/discovery/OpenIDProviderMetadata.java
@@ -57,6 +57,9 @@ public class OpenIDProviderMetadata {
     @JsonProperty("registration_endpoint")
     private String registrationEndpoint;
 
+    @JsonProperty("registration_renew_secret_endpoint")
+    private String registrationRenewSecretEndpoint;
+
     @JsonProperty("scopes_supported")
     private List<String> scopesSupported;
 
@@ -217,6 +220,14 @@ public class OpenIDProviderMetadata {
 
     public void setRegistrationEndpoint(String registrationEndpoint) {
         this.registrationEndpoint = registrationEndpoint;
+    }
+
+    public String getRegistrationRenewSecretEndpoint() {
+        return registrationRenewSecretEndpoint;
+    }
+
+    public void setRegistrationRenewSecretEndpoint(String registrationRenewSecretEndpoint) {
+        this.registrationRenewSecretEndpoint = registrationRenewSecretEndpoint;
     }
 
     public List<String> getScopesSupported() {

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/discovery/impl/OpenIDDiscoveryServiceImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oidc/service/discovery/impl/OpenIDDiscoveryServiceImpl.java
@@ -73,6 +73,7 @@ public class OpenIDDiscoveryServiceImpl implements OpenIDDiscoveryService {
         openIDProviderMetadata.setIntrospectionEndpoint(getEndpointAbsoluteURL(basePath, INTROSPECTION_ENDPOINT));
         openIDProviderMetadata.setEndSessionEndpoint(getEndpointAbsoluteURL(basePath, ENDSESSION_ENDPOINT));
         openIDProviderMetadata.setRegistrationEndpoint(getEndpointAbsoluteURL(basePath, REGISTRATION_ENDPOINT));
+        openIDProviderMetadata.setRegistrationRenewSecretEndpoint(openIDProviderMetadata.getRegistrationEndpoint()+"/:client_id/renew_secret");
 
         // supported parameters
         openIDProviderMetadata.setScopesSupported(scopeService.getDiscoveryScope());

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/clientregistration/DynamicClientRegistrationRequestTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oidc/service/clientregistration/DynamicClientRegistrationRequestTest.java
@@ -69,7 +69,27 @@ public class DynamicClientRegistrationRequestTest {
         assertEquals("Refresh token validity should have been kept",3600, result.getRefreshTokenValiditySeconds());
         assertEquals("Default Max Age should have been kept",Integer.valueOf(1),result.getDefaultMaxAge());
         assertArrayEquals("Grant types should have been replaced",Arrays.asList("grant1","grant2").toArray(),result.getAuthorizedGrantTypes().toArray());
-        assertArrayEquals("Response type should have been replaced by default values",Arrays.asList("code").toArray(),result.getResponseTypes().toArray());
+        assertNull("Response type should have been set to null", result.getResponseTypes());
+        assertArrayEquals("Scopes should have been replaced",Arrays.asList("scope1","scope2").toArray(), result.getScopes().toArray());
+    }
+
+    @Test
+    public void testPatch_nullValues() {
+        patcher.setResponseTypes(null);
+
+        //Apply patch
+        Client result = patcher.patch(toPatch);
+
+        //Checks
+        assertNotNull(result);
+        assertEquals("Client name should have been replaced","expectedClientName",result.getClientName());
+        assertEquals("Client secret should have been kept","expectedSecret", result.getClientSecret());
+        assertNull("Client uri should have been erased",result.getClientUri());
+        assertEquals("Access token validity should have been kept",7200,result.getAccessTokenValiditySeconds());
+        assertEquals("Refresh token validity should have been kept",3600, result.getRefreshTokenValiditySeconds());
+        assertEquals("Default Max Age should have been kept",Integer.valueOf(1),result.getDefaultMaxAge());
+        assertArrayEquals("Grant types should have been replaced",Arrays.asList("grant1","grant2").toArray(),result.getAuthorizedGrantTypes().toArray());
+        assertArrayEquals("Response type should have not been replaced",Arrays.asList("old","old2").toArray(),result.getResponseTypes().toArray());
         assertArrayEquals("Scopes should have been replaced",Arrays.asList("scope1","scope2").toArray(), result.getScopes().toArray());
     }
 
@@ -87,7 +107,33 @@ public class DynamicClientRegistrationRequestTest {
         assertEquals("Refresh token validity should have been kept",3600, result.getRefreshTokenValiditySeconds());
         assertArrayEquals("Grant types should have been replaced",Arrays.asList("grant1","grant2").toArray(),result.getAuthorizedGrantTypes().toArray());
         assertArrayEquals("Scopes should have been replaced",Arrays.asList("scope1","scope2").toArray(), result.getScopes().toArray());
-        assertNull("Response type should be set to null", result.getResponseTypes());
+        assertNull("Response type should have been set to null", result.getResponseTypes());
         assertNull("Default max age should be set to null", result.getDefaultMaxAge());
+    }
+
+    @Test
+    public void testUpdate_nullValues() {
+        patcher.setResponseTypes(null);
+
+        //Apply update
+        Client result = patcher.update(toPatch);
+
+        //Checks
+        assertNotNull(result);
+        assertEquals("Client name should have been replaced","expectedClientName",result.getClientName());
+        assertEquals("Client secret should have been kept","expectedSecret", result.getClientSecret());
+        assertNull("Client uri should have been erased",result.getClientUri());
+        assertEquals("Access token validity should have been kept",7200,result.getAccessTokenValiditySeconds());
+        assertEquals("Refresh token validity should have been kept",3600, result.getRefreshTokenValiditySeconds());
+        assertArrayEquals("Grant types should have been replaced",Arrays.asList("grant1","grant2").toArray(),result.getAuthorizedGrantTypes().toArray());
+        assertArrayEquals("Scopes should have been replaced",Arrays.asList("scope1","scope2").toArray(), result.getScopes().toArray());
+        assertNull("Response type should have been set to null", result.getResponseTypes());
+        assertNull("Default max age should be set to null", result.getDefaultMaxAge());
+    }
+
+    @Test
+    public void testGetScope() {
+        patcher.setScope(Optional.of(""));
+        assertFalse(patcher.getScope().isPresent());
     }
 }

--- a/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/ClientRegistrationSettings.java
+++ b/gravitee-am-model/src/main/java/io/gravitee/am/model/oidc/ClientRegistrationSettings.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.am.model.oidc;
 
+import java.util.List;
+
 /**
  * @author Alexandre FARIA (contact at alexandrefaria.net)
  * @author GraviteeSource Team
@@ -45,6 +47,21 @@ public class ClientRegistrationSettings {
      * Domain open Dynamic Client Registration enabled
      */
     private boolean isOpenDynamicClientRegistrationEnabled;
+
+    /**
+     * Define some default scopes to add on each client registration request
+     */
+    private List<String> defaultScopes;
+
+    /**
+     * Filter scopes on Client Registration through an allowed list of scopes enabled.
+     */
+    private boolean isAllowedScopesEnabled;
+
+    /**
+     * Define allowed scopes for each client registration request
+     */
+    private List<String> allowedScopes;
 
 
     public boolean isAllowLocalhostRedirectUri() {
@@ -90,5 +107,29 @@ public class ClientRegistrationSettings {
     public static ClientRegistrationSettings defaultSettings() {
         //By default all boolean are set to false.
         return new ClientRegistrationSettings();
+    }
+
+    public List<String> getDefaultScopes() {
+        return defaultScopes;
+    }
+
+    public void setDefaultScopes(List<String> defaultScopes) {
+        this.defaultScopes = defaultScopes;
+    }
+
+    public boolean isAllowedScopesEnabled() {
+        return isAllowedScopesEnabled;
+    }
+
+    public void setAllowedScopesEnabled(boolean allowedScopesEnabled) {
+        isAllowedScopesEnabled = allowedScopesEnabled;
+    }
+
+    public List<String> getAllowedScopes() {
+        return allowedScopes;
+    }
+
+    public void setAllowedScopes(List<String> allowedScopes) {
+        this.allowedScopes = allowedScopes;
     }
 }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoDomainRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoDomainRepository.java
@@ -226,6 +226,9 @@ public class MongoDomainRepository extends AbstractManagementMongoRepository imp
         result.setAllowWildCardRedirectUri(dcrMongo.isAllowWildCardRedirectUri());
         result.setDynamicClientRegistrationEnabled(dcrMongo.isDynamicClientRegistrationEnabled());
         result.setOpenDynamicClientRegistrationEnabled(dcrMongo.isOpenDynamicClientRegistrationEnabled());
+        result.setDefaultScopes(dcrMongo.getDefaultScopes());
+        result.setAllowedScopesEnabled(dcrMongo.isAllowedScopesEnabled());
+        result.setAllowedScopes(dcrMongo.getAllowedScopes());
 
         return result;
     }
@@ -252,6 +255,9 @@ public class MongoDomainRepository extends AbstractManagementMongoRepository imp
         result.setAllowWildCardRedirectUri(dcr.isAllowWildCardRedirectUri());
         result.setDynamicClientRegistrationEnabled(dcr.isDynamicClientRegistrationEnabled());
         result.setOpenDynamicClientRegistrationEnabled(dcr.isOpenDynamicClientRegistrationEnabled());
+        result.setDefaultScopes(dcr.getDefaultScopes());
+        result.setAllowedScopesEnabled(dcr.isAllowedScopesEnabled());
+        result.setAllowedScopes(dcr.getAllowedScopes());
 
         return result;
     }

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/IdentityProviderMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/IdentityProviderMongo.java
@@ -19,8 +19,6 @@ import io.gravitee.am.repository.mongodb.common.model.Auditable;
 import org.bson.Document;
 import org.bson.codecs.pojo.annotations.BsonId;
 
-import java.util.Map;
-
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/ScopeMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/ScopeMongo.java
@@ -19,7 +19,6 @@ import io.gravitee.am.repository.mongodb.common.model.Auditable;
 import org.bson.codecs.pojo.annotations.BsonId;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/oidc/ClientRegistrationSettingsMongo.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/internal/model/oidc/ClientRegistrationSettingsMongo.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.am.repository.mongodb.management.internal.model.oidc;
 
+import java.util.List;
+
 /**
  * @author Alexandre FARIA (contact at alexandrefaria.net)
  * @author GraviteeSource Team
@@ -26,6 +28,10 @@ public class ClientRegistrationSettingsMongo {
     private boolean allowWildCardRedirectUri;
     private boolean isDynamicClientRegistrationEnabled;
     private boolean isOpenDynamicClientRegistrationEnabled;
+    private List<String> defaultScopes;
+    private boolean isAllowedScopesEnabled;
+    private List<String> allowedScopes;
+
 
     public boolean isAllowLocalhostRedirectUri() {
         return allowLocalhostRedirectUri;
@@ -65,5 +71,29 @@ public class ClientRegistrationSettingsMongo {
 
     public void setAllowWildCardRedirectUri(boolean allowWildCardRedirectUri) {
         this.allowWildCardRedirectUri = allowWildCardRedirectUri;
+    }
+
+    public List<String> getDefaultScopes() {
+        return defaultScopes;
+    }
+
+    public void setDefaultScopes(List<String> defaultScopes) {
+        this.defaultScopes = defaultScopes;
+    }
+
+    public boolean isAllowedScopesEnabled() {
+        return isAllowedScopesEnabled;
+    }
+
+    public void setAllowedScopesEnabled(boolean allowedScopesEnabled) {
+        isAllowedScopesEnabled = allowedScopesEnabled;
+    }
+
+    public List<String> getAllowedScopes() {
+        return allowedScopes;
+    }
+
+    public void setAllowedScopes(List<String> allowedScopes) {
+        this.allowedScopes = allowedScopes;
     }
 }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/model/openid/PatchClientRegistrationSettings.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/model/openid/PatchClientRegistrationSettings.java
@@ -18,6 +18,8 @@ package io.gravitee.am.service.model.openid;
 import io.gravitee.am.model.oidc.ClientRegistrationSettings;
 import io.gravitee.am.service.utils.SetterUtils;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -53,6 +55,20 @@ public class PatchClientRegistrationSettings {
      */
     private Optional<Boolean> isOpenDynamicClientRegistrationEnabled;
 
+    /**
+     * Define some default scope to add on each client registration request
+     */
+    private Optional<List<String>> defaultScopes;
+
+    /**
+     * Filter scopes on Client Registration through an allowed list of scopes enabled.
+     */
+    private Optional<Boolean> isAllowedScopesEnabled;
+
+    /**
+     * Define allowed scopes for each client registration request
+     */
+    private Optional<List<String>> allowedScopes;
 
     public Optional<Boolean> getAllowLocalhostRedirectUri() {
         return allowLocalhostRedirectUri;
@@ -94,6 +110,29 @@ public class PatchClientRegistrationSettings {
         this.isOpenDynamicClientRegistrationEnabled = isOpenDynamicClientRegistrationEnabled;
     }
 
+    public Optional<List<String>> getDefaultScopes() {
+        return defaultScopes;
+    }
+
+    public void setDefaultScopes(Optional<List<String>> defaultScopes) {
+        this.defaultScopes = defaultScopes;
+    }
+
+    public Optional<Boolean> isAllowedScopesEnabled() {
+        return isAllowedScopesEnabled;
+    }
+
+    public void setIsAllowedScopesEnabled(Optional<Boolean> isAllowedScopesEnabled) {
+        this.isAllowedScopesEnabled = isAllowedScopesEnabled;
+    }
+
+    public Optional<List<String>> getAllowedScopes() {
+        return allowedScopes;
+    }
+
+    public void setAllowedScopes(Optional<List<String>> allowedScopes) {
+        this.allowedScopes = allowedScopes;
+    }
 
     public ClientRegistrationSettings patch(ClientRegistrationSettings toPatch) {
         ClientRegistrationSettings result=toPatch!=null?toPatch: ClientRegistrationSettings.defaultSettings();
@@ -102,7 +141,10 @@ public class PatchClientRegistrationSettings {
         SetterUtils.safeSet(result::setAllowHttpSchemeRedirectUri, this.getAllowHttpSchemeRedirectUri(), boolean.class);
         SetterUtils.safeSet(result::setAllowLocalhostRedirectUri, this.getAllowLocalhostRedirectUri(), boolean.class);
         SetterUtils.safeSet(result::setOpenDynamicClientRegistrationEnabled, this.isOpenDynamicClientRegistrationEnabled(), boolean.class);
-        SetterUtils.safeSet(result::setDynamicClientRegistrationEnabled,this.isDynamicClientRegistrationEnabled(), boolean.class);
+        SetterUtils.safeSet(result::setDynamicClientRegistrationEnabled, this.isDynamicClientRegistrationEnabled(), boolean.class);
+        SetterUtils.safeSet(result::setDefaultScopes, this.getDefaultScopes());
+        SetterUtils.safeSet(result::setAllowedScopesEnabled, this.isAllowedScopesEnabled, boolean.class);
+        SetterUtils.safeSet(result::setAllowedScopes, this.getAllowedScopes());
 
         return result;
     }

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/utils/SetterUtils.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/utils/SetterUtils.java
@@ -70,20 +70,6 @@ public class SetterUtils {
         }
     }
 
-    /**
-     * Safe setter, apply setter only if Optional is not null.
-     * Apply default value if Optional is empty.
-     * @param setter Consumer setter method.
-     * @param value Optional value.
-     * @param defaultValue Default value to apply if Optional is empty.
-     * @param <T> value class
-     */
-    public static <T> void safeSetOrElse(final Consumer<T> setter, final Optional<T> value, final T defaultValue) {
-        if (value != null) {
-            setter.accept(value.orElse(defaultValue));
-        }
-    }
-
     private static Object getDefaultValue(Class primitive) {
 
         if (primitive.equals(boolean.class)) {

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/utils/GrantTypeUtilsTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/utils/GrantTypeUtilsTest.java
@@ -23,6 +23,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.util.Arrays;
+import java.util.Optional;
 
 import static org.junit.Assert.*;
 
@@ -96,6 +97,19 @@ public class GrantTypeUtilsTest {
 
         testObserver.assertNotComplete();
         testObserver.assertError(InvalidClientMetadataException.class);
+    }
+
+    @Test
+    public void validateGrantTypes_refreshToken_ko() {
+        Client client = new Client();
+        client.setAuthorizedGrantTypes(Arrays.asList("refresh_token"));
+        client.setResponseTypes(Arrays.asList());
+
+        TestObserver<Client> testObserver = GrantTypeUtils.validateGrantTypes(client).test();
+
+        testObserver.assertError(InvalidClientMetadataException.class);
+        testObserver.assertError(err -> ((Throwable)err).getMessage().startsWith("refresh_token grant type must be associated with"));
+        testObserver.assertNotComplete();
     }
 
     @Test

--- a/gravitee-am-service/src/test/java/io/gravitee/am/service/utils/SetterUtilsTest.java
+++ b/gravitee-am-service/src/test/java/io/gravitee/am/service/utils/SetterUtilsTest.java
@@ -116,29 +116,6 @@ public class SetterUtilsTest {
     }
 
     @Test
-    public void testSafeSetOrElse_optionalIsNull() {
-        BasicDto basic = new BasicDto();
-        SetterUtils.safeSetOrElse(basic::setString,null,"orElse");
-        assertNull("was expecting a null value",basic.getString());
-    }
-
-    @Test
-    public void testSafeSetOrElse_optionalIsEmpty() {
-        BasicDto basic = new BasicDto();
-        SetterUtils.safeSetOrElse(basic::setString,Optional.empty(),"orElse");
-        assertNotNull("was expecting a non null value",basic.getString());
-        assertEquals("orElse",basic.getString());
-    }
-
-    @Test
-    public void testSafeSetOrElse_optionalIsNotEmpty() {
-        BasicDto basic = new BasicDto();
-        SetterUtils.safeSetOrElse(basic::setString,Optional.of("succeed"),"wasEmpty");
-        assertNotNull(basic.getString());
-        assertEquals("succeed",basic.getString());
-    }
-
-    @Test
     public void testSet_optionalIsNull() {
         BasicDto basic = new BasicDto();
         SetterUtils.set(basic::setString,null);

--- a/gravitee-am-ui/src/app/app-routing.module.ts
+++ b/gravitee-am-ui/src/app/app-routing.module.ts
@@ -23,6 +23,9 @@ import {DomainDashboardComponent} from "./domain/dashboard/dashboard.component";
 import {DomainSettingsComponent} from "./domain/settings/settings.component";
 import {DomainSettingsGeneralComponent} from "./domain/settings/general/general.component";
 import {DomainSettingsOpenidClientRegistrationComponent} from "./domain/settings/openid/client-registration/client-registration.component";
+import {ClientRegistrationSettingsComponent} from "./domain/settings/openid/client-registration/settings/settings.component";
+import {ClientRegistrationDefaultScopeComponent} from "./domain/settings/openid/client-registration/default-scope/default-scope.component";
+import {ClientRegistrationAllowedScopeComponent} from "./domain/settings/openid/client-registration/allowed-scope/allowed-scope.component";
 import {DomainSettingsCertificatesComponent} from "./domain/settings/certificates/certificates.component";
 import {DomainSettingsProvidersComponent} from "./domain/settings/providers/providers.component";
 import {DomainSettingsRolesComponent} from "./domain/settings/roles/roles.component";
@@ -735,7 +738,13 @@ const routes: Routes = [
                 label: 'Client Registration',
                 section: 'Openid'
               }
-            }
+            },
+            children: [
+              { path: '', redirectTo: 'settings', pathMatch: 'full' },
+              { path: 'settings', component: ClientRegistrationSettingsComponent, resolve: {domain: DomainResolver} },
+              { path: 'default-scope', component: ClientRegistrationDefaultScopeComponent, resolve: {domain: DomainResolver, scopes: ScopesResolver}},
+              { path: 'allowed-scope', component: ClientRegistrationAllowedScopeComponent, resolve: {domain: DomainResolver, scopes: ScopesResolver}},
+            ]
           }
         ]
       }

--- a/gravitee-am-ui/src/app/app.module.ts
+++ b/gravitee-am-ui/src/app/app.module.ts
@@ -90,6 +90,9 @@ import { DomainDashboardComponent } from "./domain/dashboard/dashboard.component
 import { DomainSettingsComponent } from './domain/settings/settings.component';
 import { DomainSettingsGeneralComponent } from "./domain/settings/general/general.component";
 import { DomainSettingsOpenidClientRegistrationComponent } from "./domain/settings/openid/client-registration/client-registration.component";
+import { ClientRegistrationSettingsComponent } from "./domain/settings/openid/client-registration/settings/settings.component";
+import { ClientRegistrationDefaultScopeComponent } from "./domain/settings/openid/client-registration/default-scope/default-scope.component";
+import { ClientRegistrationAllowedScopeComponent } from "./domain/settings/openid/client-registration/allowed-scope/allowed-scope.component";
 import { DomainSettingsRolesComponent } from "./domain/settings/roles/roles.component";
 import { DomainSettingsScopesComponent } from "./domain/settings/scopes/scopes.component";
 import { DomainSettingsCertificatesComponent, CertitificatePublicKeyDialog } from './domain/settings/certificates/certificates.component';
@@ -205,6 +208,7 @@ import { HttpRequestInterceptor } from "./interceptors/http-request.interceptor"
 import { PolicyFormComponent } from "./domain/settings/policies/policy/form/form.component";
 import { PolicyService } from "./services/policy.service";
 import { PoliciesResolver } from "./resolvers/policies.resolver";
+import { ScopeSelectionComponent} from "./domain/components/scope-selection/scope-selection.component";
 
 @NgModule({
   declarations: [
@@ -219,6 +223,9 @@ import { PoliciesResolver } from "./resolvers/policies.resolver";
     DomainSettingsComponent,
     DomainSettingsGeneralComponent,
     DomainSettingsOpenidClientRegistrationComponent,
+    ClientRegistrationSettingsComponent,
+    ClientRegistrationDefaultScopeComponent,
+    ClientRegistrationAllowedScopeComponent,
     DomainSettingsProvidersComponent,
     DomainSettingsScopesComponent,
     DomainSettingsRolesComponent,
@@ -321,7 +328,8 @@ import { PoliciesResolver } from "./resolvers/policies.resolver";
     TagComponent,
     AccountSettingsComponent,
     PolicyFormComponent,
-    PoliciesInfoDialog
+    PoliciesInfoDialog,
+    ScopeSelectionComponent
   ],
   imports: [
     BrowserModule,

--- a/gravitee-am-ui/src/app/domain/components/scope-selection/scope-selection.component.html
+++ b/gravitee-am-ui/src/app/domain/components/scope-selection/scope-selection.component.html
@@ -1,0 +1,79 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="scope-container" fxLayout="column">
+
+  <mat-form-field>
+    <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Filter">
+  </mat-form-field>
+
+  <table mat-table [dataSource]="scopes" matSort matSortActive="select" matSortDirection="asc" class="mat-elevation-z8">
+
+    <!-- Checkbox Column -->
+    <ng-container matColumnDef="select">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>
+        <mat-checkbox (change)="$event ? masterToggle() : null"
+                      [checked]="selection.hasValue() && isAllSelected()"
+                      [indeterminate]="selection.hasValue() && !isAllSelected()"
+                      [aria-label]="checkboxLabel()">
+        </mat-checkbox>
+      </th>
+      <td mat-cell *matCellDef="let row">
+        <mat-checkbox (click)="$event.stopPropagation()"
+                      (change)="$event ? applyChange(row) : null"
+                      [checked]="selection.isSelected(row)"
+                      [aria-label]="checkboxLabel(row)">
+        </mat-checkbox>
+      </td>
+    </ng-container>
+
+    <!-- ID Column -->
+    <ng-container matColumnDef="id">
+      <th mat-header-cell *matHeaderCellDef> Id. </th>
+      <td mat-cell *matCellDef="let scope"> {{scope.id}} </td>
+    </ng-container>
+
+    <!-- Key Column -->
+    <ng-container matColumnDef="key">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header> Key </th>
+      <td mat-cell *matCellDef="let scope"> {{scope.key}} </td>
+    </ng-container>
+
+    <!-- Name Column -->
+    <ng-container matColumnDef="name">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header> Name </th>
+      <td mat-cell *matCellDef="let scope"> {{scope.name}} </td>
+    </ng-container>
+
+    <!-- Description Column -->
+    <ng-container matColumnDef="description">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header> Description </th>
+      <td mat-cell *matCellDef="let scope"> {{scope.description}} </td>
+    </ng-container>
+
+    <!-- Description Column -->
+    <ng-container matColumnDef="discovery">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header> Discovery </th>
+      <td mat-cell *matCellDef="let scope"> {{scope.discovery}} </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;"
+        (click)="selection.toggle(row)">
+    </tr>
+  </table>
+</div>

--- a/gravitee-am-ui/src/app/domain/components/scope-selection/scope-selection.component.scss
+++ b/gravitee-am-ui/src/app/domain/components/scope-selection/scope-selection.component.scss
@@ -1,0 +1,39 @@
+/*!*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+.scope-container {
+  margin-bottom: 30px;
+  mat-hint {
+    font-size: 75%;
+  }
+}
+.mat-column-select {
+  overflow: initial;
+}
+
+.mat-form-field {
+  font-size: 14px;
+  width: 100%;
+}
+
+table {
+  width: 100%;
+  background: transparent;
+  box-shadow: none;
+}
+
+th.mat-sort-header-sorted {
+  color: black;
+}

--- a/gravitee-am-ui/src/app/domain/components/scope-selection/scope-selection.component.ts
+++ b/gravitee-am-ui/src/app/domain/components/scope-selection/scope-selection.component.ts
@@ -1,0 +1,110 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {AfterViewInit, Component, EventEmitter, Input, OnInit, Output, ViewChild} from '@angular/core';
+import {MatSort, MatTableDataSource} from '@angular/material';
+import {SelectionModel} from '@angular/cdk/collections';
+import {ActivatedRoute} from '@angular/router';
+import * as _ from 'lodash';
+
+export interface Scope {
+  id: string;
+  key: string;
+  name: string;
+  description: string;
+  discovery: boolean;
+}
+
+@Component({
+  selector: 'scope-selection',
+  templateUrl: './scope-selection.component.html',
+  styleUrls: ['./scope-selection.component.scss']
+})
+
+export class ScopeSelectionComponent implements OnInit, AfterViewInit {
+  @Output() onScopeSelection = new EventEmitter();
+  @Input() initialSelectedScopes: string[];
+
+  scopes: MatTableDataSource<Scope>;
+  selection: SelectionModel<Scope>;
+  displayedColumns: string[] = ['select', 'key', 'name', 'description'];
+
+  @ViewChild(MatSort) sort: MatSort;
+
+  constructor(private route: ActivatedRoute) {}
+
+  ngOnInit() {
+    const datasource = _.map(this.route.snapshot.data['scopes'],  scope => <Scope>{
+      id: scope.id, key: scope.key, name: scope.name, description: scope.description, discovery: scope.discovery
+    });
+    this.scopes = new MatTableDataSource(datasource);
+    const initialSelectedValues = _.intersectionWith(this.scopes.data, this.initialSelectedScopes, (scope, key) => scope.key === key);
+    this.selection = new SelectionModel<Scope>(true, _.compact(initialSelectedValues));
+  }
+
+  ngAfterViewInit() {
+    // implement custom sort to manage select checkbox
+    this.scopes.sortingDataAccessor = (scope, property) => {
+      switch (property) {
+        case 'select': {
+          return this.selection.isSelected(scope) ? 0 : 1;
+        }
+        default: {
+          return scope[property];
+        }
+      }
+    };
+    this.applySort();
+  }
+
+  applyChange(row) {
+    this.selection.toggle(row);
+    this.applySort();
+    this.onScopeSelection.emit(this.selection.selected);
+  }
+
+  /** Apply sort on table */
+  applySort() {
+    this.scopes.sort = this.sort;
+  }
+
+  /** Apply filter on table */
+  applyFilter(filterValue: string) {
+    this.scopes.filter = filterValue.trim().toLowerCase();
+  }
+
+  /** Whether the number of selected elements matches the total number of rows. */
+  isAllSelected() {
+    const numSelected = this.selection.selected.length;
+    const numRows = this.scopes.data.length;
+    return numSelected === numRows;
+  }
+
+  /** Selects all rows if they are not all selected; otherwise clear selection. */
+  masterToggle() {
+    this.isAllSelected() ?
+      this.selection.clear() :
+      this.scopes.data.forEach(row => this.selection.select(row));
+    this.onScopeSelection.emit(this.selection.selected);
+  }
+
+  /** The label for the checkbox on the passed row */
+  checkboxLabel(row?: Scope): string {
+    if (!row) {
+      return `${this.isAllSelected() ? 'select' : 'deselect'} all`;
+    }
+    return `${this.selection.isSelected(row) ? 'deselect' : 'select'} row ${row.id + 1}`;
+  }
+}

--- a/gravitee-am-ui/src/app/domain/settings/openid/client-registration/allowed-scope/allowed-scope.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/openid/client-registration/allowed-scope/allowed-scope.component.html
@@ -1,0 +1,57 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="domain-client-registration-allowed-scope-container">
+  <div class="domain-client-registration-allowed-scope-content" *ngIf="dcrIsEnabled">
+    <div fxLayout="column" fxFlex="70">
+      <form (ngSubmit)="patch()" #allowedScopeForm="ngForm" fxLayout="column">
+
+        <div class="domain-client-registration-allowed-scope-state" fxLayout="column">
+          <mat-slide-toggle
+            (change)="enableAllowedScopesFilter($event)"
+            [checked]="isAllowedScopesEnabled">
+            Enable scopes restriction on client registration
+          </mat-slide-toggle>
+        </div>
+
+        <scope-selection
+          [initialSelectedScopes]="initialSelectedScopes"
+          (onScopeSelection)="onChange($event)"
+          *ngIf="isAllowedScopesEnabled">
+        </scope-selection>
+
+        <div class="domain-client-registration-allowed-scope-form-actions">
+          <button mat-raised-button [disabled]="(!allowedScopeForm.valid || allowedScopeForm.pristine) && !formChanged" type="submit">SAVE</button>
+        </div>
+      </form>
+    </div>
+    <div class="domain-client-registration-allowed-scope-description" fxFlex>
+      <h3>Allowed scopes</h3>
+      <div class="domain-client-registration-allowed-scope-description-content">
+        <p>
+          This section is used to define which scopes can be selected by third parties when they register a client through the Openid Connect Dynamic Client Registration endpoint.
+        </p>
+        <small><i>On the client registration process, access management will only retain the allowed scopes (if enabled).<br>
+          After applying this filter, if there is no more requested scopes, access management may add some default scopes.</i></small>
+      </div>
+    </div>
+  </div>
+  <app-emptystate *ngIf="!dcrIsEnabled"
+                  [message]="'Openid Connect Dynamic Client Registration is disabled.'"
+                  [subMessage]="'This feature can be enable through the Settings tab.'">
+  </app-emptystate>
+</div>

--- a/gravitee-am-ui/src/app/domain/settings/openid/client-registration/allowed-scope/allowed-scope.component.scss
+++ b/gravitee-am-ui/src/app/domain/settings/openid/client-registration/allowed-scope/allowed-scope.component.scss
@@ -1,0 +1,60 @@
+.mat-column-select {
+  overflow: initial;
+}
+
+.mat-form-field {
+  font-size: 14px;
+  width: 100%;
+}
+
+table {
+  width: 100%;
+  background: transparent;
+  box-shadow: none;
+}
+
+th.mat-sort-header-sorted {
+  color: black;
+}
+
+.domain-client-registration-allowed-scope-container {
+  padding: 10px 10px 10px 10px;
+  h1 {
+    font-weight: 400;
+  }
+  .domain-client-registration-allowed-scope-content {
+    form {
+      padding: 20px;
+      background: #fafafa;
+      border-radius: 2px;
+      border: 1px solid rgb(226, 229, 231);
+
+      .domain-client-registration-allowed-scope-state {
+        margin-bottom: 30px;
+        mat-hint {
+          font-size: 75%;
+        }
+      }
+      .domain-client-registration-allowed-scope-form-actions {
+        margin-top: 20px;
+      }
+    }
+    .domain-client-registration-allowed-scope-description {
+      margin-left: 20px;
+      h3 {
+        font-weight: 400;
+      }
+      .domain-client-registration-allowed-scope-description-content {
+        border-top: 1px solid rgb(226, 229, 231);
+        p {
+          margin-top: 20px;
+          font-size: 14px;
+        }
+        small {
+          font-size: 12px;
+          color: rgba(0, 0, 0, 0.38);
+        }
+      }
+    }
+  }
+}

--- a/gravitee-am-ui/src/app/domain/settings/openid/client-registration/allowed-scope/allowed-scope.component.spec.ts
+++ b/gravitee-am-ui/src/app/domain/settings/openid/client-registration/allowed-scope/allowed-scope.component.spec.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+

--- a/gravitee-am-ui/src/app/domain/settings/openid/client-registration/allowed-scope/allowed-scope.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/openid/client-registration/allowed-scope/allowed-scope.component.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Component, OnInit} from '@angular/core';
+import {ActivatedRoute} from '@angular/router';
+import * as _ from 'lodash';
+import {DomainService} from '../../../../../services/domain.service';
+import {SnackbarService} from '../../../../../services/snackbar.service';
+import {Scope} from '../../../../components/scope-selection/scope-selection.component';
+
+@Component({
+  selector: 'app-openid-client-registration-allowed-scope',
+  templateUrl: './allowed-scope.component.html',
+  styleUrls: ['./allowed-scope.component.scss']
+})
+
+export class ClientRegistrationAllowedScopeComponent implements OnInit {
+  domain: any = {};
+  formChanged: boolean;
+  dcrIsEnabled: boolean;
+  isAllowedScopesEnabled: boolean;
+
+  initialSelectedScopes: string[];
+  selectedScopes: Scope[];
+
+  constructor(private domainService: DomainService, private route: ActivatedRoute,
+              private snackbarService: SnackbarService) {
+  }
+
+  ngOnInit() {
+    this.domain = this.route.snapshot.data['domain'];
+    this.dcrIsEnabled = this.domain.oidc.clientRegistrationSettings.isDynamicClientRegistrationEnabled;
+    this.isAllowedScopesEnabled = this.domain.oidc.clientRegistrationSettings.isAllowedScopesEnabled;
+    this.initialSelectedScopes = this.domain.oidc.clientRegistrationSettings.allowedScopes;
+  }
+
+  enableAllowedScopesFilter(event) {
+    this.isAllowedScopesEnabled = event.checked;
+    this.formChanged = true;
+  }
+
+  onChange(currentSelectedScopes) {
+    this.selectedScopes = currentSelectedScopes;
+    this.formChanged = true;
+  }
+
+  patch() {
+    const domain = {
+      oidc: {
+        clientRegistrationSettings: {
+          allowedScopes: _.map(this.selectedScopes, scope => scope.key),
+          isAllowedScopesEnabled: this.isAllowedScopesEnabled
+        }
+      }
+    };
+
+    this.domainService.patchOpenidDCRSettings(this.domain.id, domain).subscribe(response => {
+      this.domain = response;
+      this.snackbarService.open('Domain ' + this.domain.name + ' updated');
+      this.formChanged = false;
+    });
+  }
+}

--- a/gravitee-am-ui/src/app/domain/settings/openid/client-registration/client-registration.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/openid/client-registration/client-registration.component.html
@@ -15,68 +15,19 @@
     limitations under the License.
 
 -->
-<div class="domain-client-registration-container">
-  <h1>Client Registration</h1>
-  <div class="domain-client-registration-content">
-    <div fxLayout="column" fxFlex="70">
-      <form (ngSubmit)="patch()" #domainForm="ngForm" fxLayout="column">
-        <div class="domain-client-registration-state" fxLayout="column">
-          <mat-slide-toggle
-            (change)="enableDynamicClientRegistration($event)"
-            [checked]="domain.oidc.clientRegistrationSettings.isDynamicClientRegistrationEnabled">
-            Enable/Disable Dynamic Client Registration.
-          </mat-slide-toggle>
-          <mat-hint>
-            Enable application owner to self register their application through an openid connect endpoint.<br>
-            The endpoint is available under the oidc Discovery service. <i>/.well-known/openid-configuration</i>
-          </mat-hint>
-        </div>
-        <div class="domain-client-registration-state" fxLayout="column">
-          <mat-slide-toggle
-            (change)="enableOpenDynamicClientRegistration($event)"
-            [checked]="domain.oidc.clientRegistrationSettings.isOpenDynamicClientRegistrationEnabled">
-            Enable/Disable Open Dynamic Client Registration
-          </mat-slide-toggle>
-          <mat-hint>Enable application owner to self register their application without needing to be authenticated.</mat-hint>
-        </div>
-        <div class="domain-client-registration-state" fxLayout="column">
-          <mat-slide-toggle
-            (change)="allowLocalhostRedirectUri($event)"
-            [checked]="domain.oidc.clientRegistrationSettings.allowLocalhostRedirectUri">
-            Allow localhost redirect uris.
-          </mat-slide-toggle>
-          <mat-hint>Allow clients to be registered with redirect_uris using localhost as host.</mat-hint>
-        </div>
-        <div class="domain-client-registration-state" fxLayout="column">
-          <mat-slide-toggle
-            (change)="allowHttpSchemeRedirectUri($event)"
-            [checked]="domain.oidc.clientRegistrationSettings.allowHttpSchemeRedirectUri">
-            Allow unsecured (http) redirect uris.
-          </mat-slide-toggle>
-          <mat-hint>Allow clients to be registered with redirect_uris using unsecured (http) scheme.</mat-hint>
-        </div>
-        <div class="domain-client-registration-state" fxLayout="column">
-          <mat-slide-toggle
-            (change)="allowWildCardRedirectUri($event)"
-            [checked]="domain.oidc.clientRegistrationSettings.allowWildCardRedirectUri">
-            Allow wildcards redirect_uris.
-          </mat-slide-toggle>
-          <mat-hint>Allow clients to be registered with redirect_uris containing wildcards.</mat-hint>
-        </div>
-        <div class="domain-client-registration-form-actions">
-          <button mat-raised-button [disabled]="(!domainForm.valid || domainForm.pristine) && !formChanged" type="submit">SAVE</button>
-        </div>
-      </form>
-    </div>
+<div class="client-registration-container">
 
-    <div class="domain-client-registration-description" fxFlex>
-      <h3>Client Registration</h3>
-      <div class="domain-client-registration-description-content">
-        <p>
-          This section is used to define business rules regarding client (application) creation within the domain.
-        </p>
-        <small><i>For some security reasons, it is strongly recommended to not allow unsecured http scheme, localhost as well as wildcard in the redirect_uri.</i></small>
-      </div>
-    </div>
+  <h1>Client Registration Settings</h1>
+  <nav mat-tab-nav-bar>
+    <a mat-tab-link
+       *ngFor="let link of navLinks"
+       [routerLink]="link.href"
+       routerLinkActive #rla="routerLinkActive"
+       [active]="rla.isActive">
+      {{link.label}}
+    </a>
+  </nav>
+  <div class="client-registration-content">
+    <router-outlet></router-outlet>
   </div>
 </div>

--- a/gravitee-am-ui/src/app/domain/settings/openid/client-registration/client-registration.component.scss
+++ b/gravitee-am-ui/src/app/domain/settings/openid/client-registration/client-registration.component.scss
@@ -1,64 +1,17 @@
-.domain-client-registration-container {
+.client-registration-container {
   padding: 20px 70px 20px 50px;
+  a.back-link {
+    color: #006CAB;
+    text-decoration: none;
+    &:hover {
+      color: #2196f3;
+      text-decoration: underline;
+    }
+  }
   h1 {
     font-weight: 400;
   }
-  .domain-client-registration-content {
-    form {
-      padding: 20px;
-      background: #fafafa;
-      border-radius: 2px;
-      border: 1px solid rgb(226, 229, 231);
-      .domain-client-registration-state {
-        margin-bottom: 30px;
-        mat-hint {
-          font-size: 75%;
-        }
-      }
-      .domain-client-registration-form-actions {
-        margin-top: 20px;
-      }
-    }
-    .domain-client-registration-description {
-      margin-left: 20px;
-      h3 {
-        font-weight: 400;
-      }
-      .domain-client-registration-description-content {
-        border-top: 1px solid rgb(226, 229, 231);
-        p {
-          margin-top: 20px;
-          font-size: 14px;
-        }
-        small {
-          font-size: 12px;
-          color: rgba(0, 0, 0, 0.38);
-        }
-      }
-    }
-  }
-}
-
-.clients-container {
-  h1 {
-    font-weight: 400;
-  }
-  ngx-datatable {
-    font-size: 14px;
-    box-shadow: none;
-  }
-
-  .badge {
-    margin-left: 5px;
-    padding: 3px 6px;
-  }
-}
-
-.clients-actions {
-  margin-left: -10px;
-
-  button, a {
-    top: -9px;
-    color: grey;
+  .client-registration-content {
+    padding: 25px 0 20px;
   }
 }

--- a/gravitee-am-ui/src/app/domain/settings/openid/client-registration/client-registration.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/openid/client-registration/client-registration.component.ts
@@ -13,20 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Component, OnInit, ViewChild} from '@angular/core';
-import { DomainService } from "../../../../services/domain.service";
-import { DialogService } from "../../../../services/dialog.service";
-import { ActivatedRoute, Router } from "@angular/router";
-import { SnackbarService } from "../../../../services/snackbar.service";
+import {Component, OnInit} from '@angular/core';
+import { ActivatedRoute } from "@angular/router";
 import { BreadcrumbService } from "../../../../../libraries/ng2-breadcrumb/components/breadcrumbService";
-import { SidenavService } from "../../../../components/sidenav/sidenav.service";
-import { ClientService } from "../../../../services/client.service";
-import { MatInput } from "@angular/material";
-
-export interface Client {
-  id: string;
-  clientId: string;
-}
 
 @Component({
   selector: 'app-openid-client-registration',
@@ -34,67 +23,27 @@ export interface Client {
   styleUrls: ['./client-registration.component.scss']
 })
 export class DomainSettingsOpenidClientRegistrationComponent implements OnInit {
-
-  @ViewChild('chipInput') chipInput: MatInput;
+  private domainId: string;
+  navLinks: any = [
+    {'href': 'settings' , 'label': 'Settings'},
+    {'href': 'default-scope' , 'label': 'Default Scopes'},
+    {'href': 'allowed-scope' , 'label': 'Allowed Scopes'}
+  ];
 
   formChanged: boolean = false;
   domain: any = {};
-  clientDcrDisabled: boolean = false;
-  disableToolTip: boolean = false;
-  toolTipMessage = "";
 
-  constructor(private domainService: DomainService, private dialogService: DialogService, private snackbarService: SnackbarService,
-              private router: Router, private route: ActivatedRoute, private breadcrumbService: BreadcrumbService, private sidenavService: SidenavService,
-              private clientService: ClientService) {
+  constructor(private route: ActivatedRoute, private breadcrumbService: BreadcrumbService) {
   }
 
   ngOnInit() {
-    this.domain = this.route.snapshot.parent.data['domain'];
+    this.domainId = this.route.snapshot.parent.data['domain'].name;
+    this.initBreadcrumb();
   }
 
-  enableDynamicClientRegistration(event) {
-    this.domain.oidc.clientRegistrationSettings.isDynamicClientRegistrationEnabled = event.checked;
-    //If disabled, ensure to disable open dynamic client registration too and disable clients toogle too.
-    if(!event.checked) {
-      this.domain.oidc.clientRegistrationSettings.isOpenDynamicClientRegistrationEnabled = event.checked;
-      this.clientDcrDisabled = !event.checked;
-      this.disableToolTip = event.checked;
-      this.toolTipMessage = "Disable until settings are saved and feature is enabled.";
-    }
-    this.formChanged = true;
-  }
-
-  enableOpenDynamicClientRegistration(event) {
-    this.domain.oidc.clientRegistrationSettings.isOpenDynamicClientRegistrationEnabled = event.checked;
-    //If enabled, ensure to enable dynamic client registration too.
-    if(event.checked) {
-      this.domain.oidc.clientRegistrationSettings.isDynamicClientRegistrationEnabled = event.checked;
-    }
-    this.formChanged = true;
-  }
-
-  allowLocalhostRedirectUri(event) {
-    this.domain.oidc.clientRegistrationSettings.allowLocalhostRedirectUri = event.checked;
-    this.formChanged = true;
-  }
-
-  allowHttpSchemeRedirectUri(event) {
-    this.domain.oidc.clientRegistrationSettings.allowHttpSchemeRedirectUri = event.checked;
-    this.formChanged = true;
-  }
-
-  allowWildCardRedirectUri(event) {
-    this.domain.oidc.clientRegistrationSettings.allowWildCardRedirectUri = event.checked;
-    this.formChanged = true;
-  }
-
-  patch() {
-    this.domainService.patchOpenidDCRSettings(this.domain.id, this.domain).subscribe(response => {
-      this.domain = response;
-      this.domainService.notify(this.domain);
-      this.sidenavService.notify(this.domain);
-      this.breadcrumbService.addFriendlyNameForRoute('/domains/'+this.domain.id, this.domain.name);
-      this.snackbarService.open("Domain " + this.domain.name + " updated");
-    });
+  initBreadcrumb() {
+    this.breadcrumbService.addFriendlyNameForRouteRegex('/domains/'+this.domainId+'/settings/openid/clientRegistration/settings', 'settings');
+    this.breadcrumbService.addFriendlyNameForRouteRegex('/domains/'+this.domainId+'/settings/openid/clientRegistration/default-scope', 'default scopes');
+    this.breadcrumbService.addFriendlyNameForRouteRegex('/domains/'+this.domainId+'/settings/openid/clientRegistration/allowed-scope', 'allowed scopes');
   }
 }

--- a/gravitee-am-ui/src/app/domain/settings/openid/client-registration/default-scope/default-scope.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/openid/client-registration/default-scope/default-scope.component.html
@@ -1,0 +1,48 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="domain-client-registration-default-scope-container">
+  <div class="domain-client-registration-default-scope-content" *ngIf="dcrIsEnabled">
+    <div fxLayout="column" fxFlex="70">
+      <form (ngSubmit)="patch()" #defaultScopeForm="ngForm" fxLayout="column">
+
+        <scope-selection
+          [initialSelectedScopes]="initialSelectedScopes"
+          (onScopeSelection)="onChange($event)">
+        </scope-selection>
+
+        <div class="domain-client-registration-default-scope-form-actions">
+          <button mat-raised-button [disabled]="(!defaultScopeForm.valid || defaultScopeForm.pristine) && !formChanged" type="submit">SAVE</button>
+        </div>
+
+      </form>
+    </div>
+    <div class="domain-client-registration-default-scope-description" fxFlex>
+      <h3>Default scopes</h3>
+      <div class="domain-client-registration-default-scope-description-content">
+        <p>
+          This section is used to define some default scope to be automatically added when a client is created through the Openid Connect Dynamic Client Registration endpoint, without any requested scopes.
+        </p>
+        <small><i>As the <a href="https://tools.ietf.org/html/rfc7591#section-2" target="_blank">specification</a> state: If omitted, an authorization server MAY register a client with a default set of scopes.</i></small>
+      </div>
+    </div>
+  </div>
+  <app-emptystate *ngIf="!dcrIsEnabled"
+                  [message]="'Openid Connect Dynamic Client Registration is disabled.'"
+                  [subMessage]="'This feature can be enable through the Settings tab.'">
+  </app-emptystate>
+</div>

--- a/gravitee-am-ui/src/app/domain/settings/openid/client-registration/default-scope/default-scope.component.scss
+++ b/gravitee-am-ui/src/app/domain/settings/openid/client-registration/default-scope/default-scope.component.scss
@@ -1,0 +1,40 @@
+.domain-client-registration-default-scope-container {
+  padding: 10px 10px 10px 10px;
+  h1 {
+    font-weight: 400;
+  }
+  .domain-client-registration-default-scope-content {
+    form {
+      padding: 20px;
+      background: #fafafa;
+      border-radius: 2px;
+      border: 1px solid rgb(226, 229, 231);
+
+      ngx-datatable {
+        background: transparent;
+        box-shadow: none;
+      }
+
+      .domain-client-registration-default-scope-form-actions {
+        margin-top: 20px;
+      }
+    }
+    .domain-client-registration-default-scope-description {
+      margin-left: 20px;
+      h3 {
+        font-weight: 400;
+      }
+      .domain-client-registration-default-scope-description-content {
+        border-top: 1px solid rgb(226, 229, 231);
+        p {
+          margin-top: 20px;
+          font-size: 14px;
+        }
+        small {
+          font-size: 12px;
+          color: rgba(0, 0, 0, 0.38);
+        }
+      }
+    }
+  }
+}

--- a/gravitee-am-ui/src/app/domain/settings/openid/client-registration/default-scope/default-scope.component.spec.ts
+++ b/gravitee-am-ui/src/app/domain/settings/openid/client-registration/default-scope/default-scope.component.spec.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/gravitee-am-ui/src/app/domain/settings/openid/client-registration/default-scope/default-scope.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/openid/client-registration/default-scope/default-scope.component.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Component, OnInit} from '@angular/core';
+import {ActivatedRoute} from '@angular/router';
+import * as _ from 'lodash';
+import {DomainService} from '../../../../../services/domain.service';
+import {SnackbarService} from '../../../../../services/snackbar.service';
+import {Scope} from '../../../../components/scope-selection/scope-selection.component';
+
+@Component({
+  selector: 'app-openid-client-registration-default-scope',
+  templateUrl: './default-scope.component.html',
+  styleUrls: ['./default-scope.component.scss']
+})
+
+export class ClientRegistrationDefaultScopeComponent implements OnInit {
+  domain: any = {};
+  formChanged: boolean;
+  dcrIsEnabled: boolean;
+
+  initialSelectedScopes: string[];
+  selectedScopes: Scope[];
+
+  constructor(private domainService: DomainService, private route: ActivatedRoute,
+              private snackbarService: SnackbarService) {
+  }
+
+  ngOnInit() {
+    this.domain = this.route.snapshot.data['domain'];
+    this.dcrIsEnabled = this.domain.oidc.clientRegistrationSettings.isDynamicClientRegistrationEnabled;
+    this.initialSelectedScopes = this.domain.oidc.clientRegistrationSettings.defaultScopes;
+  }
+
+  onChange(currentSelectedScopes) {
+    this.selectedScopes = currentSelectedScopes;
+    this.formChanged = true;
+  }
+
+  patch() {
+    const domain = {
+      oidc: {
+        clientRegistrationSettings: {
+          defaultScopes: _.map(this.selectedScopes, scope => scope.key)
+        }
+      }
+    };
+
+    this.domainService.patchOpenidDCRSettings(this.domain.id, domain).subscribe(response => {
+      this.domain = response;
+      this.snackbarService.open('Domain ' + this.domain.name + ' updated');
+      this.formChanged = false;
+    });
+  }
+}

--- a/gravitee-am-ui/src/app/domain/settings/openid/client-registration/settings/settings.component.html
+++ b/gravitee-am-ui/src/app/domain/settings/openid/client-registration/settings/settings.component.html
@@ -1,0 +1,81 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="domain-client-registration-settings-container">
+  <div class="domain-client-registration-settings-content">
+    <div fxLayout="column" fxFlex="70">
+      <form (ngSubmit)="patch()" #domainForm="ngForm" fxLayout="column">
+        <div class="domain-client-registration-settings-state" fxLayout="column">
+          <mat-slide-toggle
+            (change)="enableDynamicClientRegistration($event)"
+            [checked]="domain.oidc.clientRegistrationSettings.isDynamicClientRegistrationEnabled">
+            Enable/Disable Dynamic Client Registration.
+          </mat-slide-toggle>
+          <mat-hint>
+            Enable application owner to self register their application through an openid connect endpoint.<br>
+            The endpoint is available under the oidc Discovery service. <i>/.well-known/openid-configuration</i>
+          </mat-hint>
+        </div>
+        <div class="domain-client-registration-settings-state" fxLayout="column">
+          <mat-slide-toggle
+            (change)="enableOpenDynamicClientRegistration($event)"
+            [checked]="domain.oidc.clientRegistrationSettings.isOpenDynamicClientRegistrationEnabled">
+            Enable/Disable Open Dynamic Client Registration
+          </mat-slide-toggle>
+          <mat-hint>Enable application owner to self register their application without needing to be authenticated.</mat-hint>
+        </div>
+        <div class="domain-client-registration-settings-state" fxLayout="column">
+          <mat-slide-toggle
+            (change)="allowLocalhostRedirectUri($event)"
+            [checked]="domain.oidc.clientRegistrationSettings.allowLocalhostRedirectUri">
+            Allow localhost redirect uris.
+          </mat-slide-toggle>
+          <mat-hint>Allow clients to be registered with redirect_uris using localhost as host.</mat-hint>
+        </div>
+        <div class="domain-client-registration-settings-state" fxLayout="column">
+          <mat-slide-toggle
+            (change)="allowHttpSchemeRedirectUri($event)"
+            [checked]="domain.oidc.clientRegistrationSettings.allowHttpSchemeRedirectUri">
+            Allow unsecured (http) redirect uris.
+          </mat-slide-toggle>
+          <mat-hint>Allow clients to be registered with redirect_uris using unsecured (http) scheme.</mat-hint>
+        </div>
+        <div class="domain-client-registration-settings-state" fxLayout="column">
+          <mat-slide-toggle
+            (change)="allowWildCardRedirectUri($event)"
+            [checked]="domain.oidc.clientRegistrationSettings.allowWildCardRedirectUri">
+            Allow wildcards redirect_uris.
+          </mat-slide-toggle>
+          <mat-hint>Allow clients to be registered with redirect_uris containing wildcards.</mat-hint>
+        </div>
+        <div class="domain-client-registration-settings-form-actions">
+          <button mat-raised-button [disabled]="(!domainForm.valid || domainForm.pristine) && !formChanged" type="submit">SAVE</button>
+        </div>
+      </form>
+    </div>
+
+    <div class="domain-client-registration-settings-description" fxFlex>
+      <h3>Client Registration</h3>
+      <div class="domain-client-registration-settings-description-content">
+        <p>
+          This section is used to define business rules regarding client (application) creation within the domain.
+        </p>
+        <small><i>For some security reasons, it is strongly recommended to not allow unsecured http scheme, localhost as well as wildcard in the redirect_uri.</i></small>
+      </div>
+    </div>
+  </div>
+</div>

--- a/gravitee-am-ui/src/app/domain/settings/openid/client-registration/settings/settings.component.scss
+++ b/gravitee-am-ui/src/app/domain/settings/openid/client-registration/settings/settings.component.scss
@@ -1,0 +1,40 @@
+.domain-client-registration-settings-container {
+  padding: 10px 10px 10px 10px;
+  h1 {
+    font-weight: 400;
+  }
+  .domain-client-registration-settings-content {
+    form {
+      padding: 20px;
+      background: #fafafa;
+      border-radius: 2px;
+      border: 1px solid rgb(226, 229, 231);
+      .domain-client-registration-settings-state {
+        margin-bottom: 30px;
+        mat-hint {
+          font-size: 75%;
+        }
+      }
+      .domain-client-registration-settings-form-actions {
+        margin-top: 20px;
+      }
+    }
+    .domain-client-registration-settings-description {
+      margin-left: 20px;
+      h3 {
+        font-weight: 400;
+      }
+      .domain-client-registration-settings-description-content {
+        border-top: 1px solid rgb(226, 229, 231);
+        p {
+          margin-top: 20px;
+          font-size: 14px;
+        }
+        small {
+          font-size: 12px;
+          color: rgba(0, 0, 0, 0.38);
+        }
+      }
+    }
+  }
+}

--- a/gravitee-am-ui/src/app/domain/settings/openid/client-registration/settings/settings.component.spec.ts
+++ b/gravitee-am-ui/src/app/domain/settings/openid/client-registration/settings/settings.component.spec.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/gravitee-am-ui/src/app/domain/settings/openid/client-registration/settings/settings.component.ts
+++ b/gravitee-am-ui/src/app/domain/settings/openid/client-registration/settings/settings.component.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Component, OnInit} from '@angular/core';
+import { DomainService } from "../../../../../services/domain.service";
+import { DialogService } from "../../../../../services/dialog.service";
+import { ActivatedRoute, Router } from "@angular/router";
+import { SnackbarService } from "../../../../../services/snackbar.service";
+import { BreadcrumbService } from "../../../../../../libraries/ng2-breadcrumb/components/breadcrumbService";
+import { SidenavService } from "../../../../../components/sidenav/sidenav.service";
+
+@Component({
+  selector: 'app-openid-client-registration-settings',
+  templateUrl: './settings.component.html',
+  styleUrls: ['./settings.component.scss']
+})
+export class ClientRegistrationSettingsComponent implements OnInit {
+
+  formChanged = false;
+  domain: any = {};
+  clientDcrDisabled = false;
+  disableToolTip = false;
+  toolTipMessage = '';
+
+  constructor(private domainService: DomainService, private dialogService: DialogService, private snackbarService: SnackbarService,
+              private router: Router, private route: ActivatedRoute, private breadcrumbService: BreadcrumbService, private sidenavService: SidenavService)
+  {}
+
+  ngOnInit() {
+    this.domain = this.route.snapshot.data['domain'];
+  }
+
+  enableDynamicClientRegistration(event) {
+    this.domain.oidc.clientRegistrationSettings.isDynamicClientRegistrationEnabled = event.checked;
+    // If disabled, ensure to disable open dynamic client registration too and disable clients toogle too.
+    if (!event.checked) {
+      this.domain.oidc.clientRegistrationSettings.isOpenDynamicClientRegistrationEnabled = event.checked;
+      this.clientDcrDisabled = !event.checked;
+      this.disableToolTip = event.checked;
+      this.toolTipMessage = "Disable until settings are saved and feature is enabled.";
+    }
+    this.formChanged = true;
+  }
+
+  enableOpenDynamicClientRegistration(event) {
+    this.domain.oidc.clientRegistrationSettings.isOpenDynamicClientRegistrationEnabled = event.checked;
+    // If enabled, ensure to enable dynamic client registration too.
+    if (event.checked) {
+      this.domain.oidc.clientRegistrationSettings.isDynamicClientRegistrationEnabled = event.checked;
+    }
+    this.formChanged = true;
+  }
+
+  allowLocalhostRedirectUri(event) {
+    this.domain.oidc.clientRegistrationSettings.allowLocalhostRedirectUri = event.checked;
+    this.formChanged = true;
+  }
+
+  allowHttpSchemeRedirectUri(event) {
+    this.domain.oidc.clientRegistrationSettings.allowHttpSchemeRedirectUri = event.checked;
+    this.formChanged = true;
+  }
+
+  allowWildCardRedirectUri(event) {
+    this.domain.oidc.clientRegistrationSettings.allowWildCardRedirectUri = event.checked;
+    this.formChanged = true;
+  }
+
+  patch() {
+    this.domainService.patchOpenidDCRSettings(this.domain.id, this.domain).subscribe(response => {
+      this.domain = response;
+      this.domainService.notify(this.domain);
+      this.sidenavService.notify(this.domain);
+      this.breadcrumbService.addFriendlyNameForRoute('/domains/' + this.domain.id, this.domain.name);
+      this.snackbarService.open('Domain ' + this.domain.name + ' updated');
+      this.formChanged = false;
+    });
+  }
+}

--- a/gravitee-am-ui/src/app/resolvers/domain.resolver.ts
+++ b/gravitee-am-ui/src/app/resolvers/domain.resolver.ts
@@ -27,7 +27,7 @@ export class DomainResolver implements Resolve<any> {
   resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<any>|Promise<any>|any {
     let domainId = AppConfig.settings.authentication.domainId;
     if (!state.url.startsWith('/settings')) {
-      domainId = (route.paramMap.get('domainId')) ? route.paramMap.get('domainId') : route.parent.paramMap.get('domainId') ? route.parent.paramMap.get('domainId') : route.parent.parent.paramMap.get('domainId');
+      domainId = (route.paramMap.get('domainId')) ? route.paramMap.get('domainId') : route.parent.paramMap.get('domainId') ? route.parent.paramMap.get('domainId') : route.parent.parent.paramMap.get('domainId') ? route.parent.parent.paramMap.get('domainId') : route.parent.parent.parent.paramMap.get('domainId');
     }
     return this.domainService.get(domainId);
   }

--- a/postman/collections/graviteeio-am-openid-dcr-collection.json
+++ b/postman/collections/graviteeio-am-openid-dcr-collection.json
@@ -503,12 +503,14 @@
 									"    pm.expect(body).to.have.property(\"revocation_endpoint\");",
 									"    pm.expect(body).to.have.property(\"userinfo_endpoint\");",
 									"    pm.expect(body).to.have.property(\"registration_endpoint\");",
+									"    pm.expect(body).to.have.property(\"registration_renew_secret_endpoint\");",
 									"",
 									"    pm.environment.set('authorizationEndpoint', body.authorization_endpoint);",
 									"    pm.environment.set('tokenEndpoint', body.token_endpoint);",
 									"    pm.environment.set('userinfoEndpoint', body.userinfo_endpoint);",
 									"    pm.environment.set('revocationEndpoint', body.revocation_endpoint);",
 									"    pm.environment.set('registrationEndpoint', body.registration_endpoint);",
+									"    pm.environment.set('registrationRenewSecretEndpoint', body.registration_renew_secret_endpoint);",
 									"});"
 								],
 								"type": "text/javascript"
@@ -897,6 +899,10 @@
 									"    var body = pm.response.json();",
 									"    pm.expect(body.client_id).to.eql(pm.environment.get('newClientIdForDCRTests'));",
 									"    pm.expect(body.client_secret).to.not.eql(pm.environment.get('newClientSecretForDCRTests'));",
+									"",
+									"    let renewSecretEndpoint = pm.environment.get('registrationClientUri')+'/renew_secret';",
+									"    let discoveryRenewSecret = pm.environment.get('registrationRenewSecretEndpoint').replace(':client_id',pm.environment.get('newClientIdForDCRTests'));",
+									"    pm.expect(renewSecretEndpoint).to.be.eql(discoveryRenewSecret);",
 									"});",
 									"",
 									"pm.test(\"One time Token\", function() {",
@@ -2600,6 +2606,106 @@
 								}
 							},
 							"response": []
+						},
+						{
+							"name": "Invalid jwks_uri",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "c557fd6b-d770-4568-8db7-ccb3267b0256",
+										"exec": [
+											"pm.test(\"Status code is 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"Invalid scope\", function () {",
+											"    pm.response.to.be.header('Content-Type', 'application/json');",
+											"    var body = pm.response.json();",
+											"    pm.expect(body.error).to.eql('invalid_client_metadata');",
+											"    pm.expect(body.error_description).to.include('Unable to parse jwks from');",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"type": "text",
+										"value": "Bearer {{access_token}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"redirect_uris\": [\n    \"https://client.example.org/callback\",\n    \"https://client.example.org/callback2\"],\n  \"client_name\": \"My Example Client\",\n   \"jwks_uri\": \"https://unbound/uri\"\n}"
+								},
+								"url": {
+									"raw": "{{registrationEndpoint}}",
+									"host": [
+										"{{registrationEndpoint}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "duplicate jwk and jwks_uri",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "c557fd6b-d770-4568-8db7-ccb3267b0256",
+										"exec": [
+											"pm.test(\"Status code is 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"Invalid scope\", function () {",
+											"    pm.response.to.be.header('Content-Type', 'application/json');",
+											"    var body = pm.response.json();",
+											"    pm.expect(body.error).to.eql('invalid_client_metadata');",
+											"    pm.expect(body.error_description).to.be.eql('The jwks_uri and jwks parameters MUST NOT be used together.');",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"type": "text",
+										"value": "Bearer {{access_token}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"redirect_uris\": [\n    \"https://client.example.org/callback\",\n    \"https://client.example.org/callback2\"],\n  \"client_name\": \"My Example Client\",\n   \"jwks_uri\": \"https://unbound/uri\",\n   \"jwks\": {\n        \"keys\": [\n\t\t\t{  \n                \"kty\": \"EC\",\n                \"use\": \"sig\",\n                \"crv\": \"P-256\",\n                \"kid\": \"elliptic-curve-signature\",\n                \"x\": \"R4JmPwezbzLuyGkonWIkezzplUfed5b6F5PL4j0zdf8\",\n                \"y\": \"QQRGKwRV9jHSlHjUhOQ0FqdQEddFBPCHZXpoFjvGmcY\"\n\t\t\t}\n        ]\n    }\n}"
+								},
+								"url": {
+									"raw": "{{registrationEndpoint}}",
+									"host": [
+										"{{registrationEndpoint}}"
+									]
+								}
+							},
+							"response": []
 						}
 					],
 					"event": [
@@ -3799,6 +3905,10 @@
 											"    var body = pm.response.json();",
 											"    pm.expect(body.client_id).to.eql(pm.environment.get('newClientIdForDCRTests'));",
 											"    pm.expect(body.client_secret).to.not.eql(pm.environment.get('newClientSecretForDCRTests'));",
+											"",
+											"    let renewSecretEndpoint = pm.environment.get('registrationClientUri')+'/renew_secret';",
+											"    let discoveryRenewSecret = pm.environment.get('registrationRenewSecretEndpoint').replace(':client_id',pm.environment.get('newClientIdForDCRTests'));",
+											"    pm.expect(renewSecretEndpoint).to.be.eql(discoveryRenewSecret);",
 											"});",
 											"",
 											"pm.test(\"One time Token\", function() {",
@@ -3916,7 +4026,7 @@
 											"    pm.expect(body.response_types).to.eql([]);",
 											"    pm.expect(body.application_type).to.eql('server');",
 											"    pm.expect(body.grant_types).to.eql(['client_credentials']);",
-											"    pm.expect(body.client_name).to.eql('Unknown Client');",
+											"    pm.expect(body.client_name).to.eql('machina');",
 											"    ",
 											"    pm.environment.set('newClientForDCRTests', body.id);",
 											"    pm.environment.set('newClientIdForDCRTests', body.client_id);",
@@ -3945,7 +4055,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"application_type\": \"server\",\n\t\"redirect_uris\": null,\n\t\"grant_types\": [\"client_credentials\"],\n\t\"response_types\": null\n}"
+									"raw": "{\n\t\"application_type\": \"server\",\n\t\"redirect_uris\": null,\n\t\"grant_types\": [\"client_credentials\"],\n\t\"response_types\": [],\n\t\"client_name\":\"machina\",\n\t\"scope\":null\n}"
 								},
 								"url": {
 									"raw": "{{registrationEndpoint}}",
@@ -4137,8 +4247,7 @@
 											"    pm.response.to.be.header('Content-Type', 'application/json');",
 											"    var body = pm.response.json();",
 											"    pm.expect(body.client_name).to.eql('Client name updated via DCR');",
-											"    pm.expect(body).to.have.property(\"response_types\");",
-											"    pm.expect(body.response_types).to.eql([]);",
+											"    pm.expect(body).not.to.have.property(\"response_types\");",
 											"    pm.expect(body).to.have.property(\"grant_types\");",
 											"    pm.expect(body.grant_types).to.eql([\"client_credentials\"]);",
 											"});",
@@ -4199,6 +4308,10 @@
 											"    var body = pm.response.json();",
 											"    pm.expect(body.client_id).to.eql(pm.environment.get('newClientIdForDCRTests'));",
 											"    pm.expect(body.client_secret).to.not.eql(pm.environment.get('newClientSecretForDCRTests'));",
+											"",
+											"    let renewSecretEndpoint = pm.environment.get('registrationClientUri')+'/renew_secret';",
+											"    let discoveryRenewSecret = pm.environment.get('registrationRenewSecretEndpoint').replace(':client_id',pm.environment.get('newClientIdForDCRTests'));",
+											"    pm.expect(renewSecretEndpoint).to.be.eql(discoveryRenewSecret);",
 											"});",
 											"",
 											"pm.test(\"One time Token\", function() {",
@@ -4238,6 +4351,449 @@
 									],
 									"path": [
 										"renew_secret"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete client - with registration token",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
+										"exec": [
+											"pm.test(\"Status code is 204\", function () {",
+											"    pm.response.to.have.status(204);",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"type": "text",
+										"value": "Bearer {{registrationAccessToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{registrationClientUri}}",
+									"host": [
+										"{{registrationClientUri}}"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"_postman_isSubFolder": true
+				},
+				{
+					"name": "case with all metadatas",
+					"item": [
+						{
+							"name": "Register client - client application",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
+										"exec": [
+											"pm.test(\"Status code is 201\", function () {",
+											"    pm.response.to.have.status(201);",
+											"});",
+											"",
+											"pm.test(\"Has default attributes\", function () {",
+											"    var body = pm.response.json();",
+											"    //Check expecting metadata",
+											"    pm.expect(body).to.have.property('grant_types');",
+											"    pm.expect(body).to.have.property('application_type');",
+											"    pm.expect(body).to.have.property('client_name');",
+											"    pm.expect(body).to.have.property('require_auth_time');",
+											"    pm.expect(body).to.have.property('client_id');",
+											"    pm.expect(body).to.have.property('client_secret');",
+											"    pm.expect(body).to.have.property('registration_access_token');",
+											"    pm.expect(body).to.have.property('registration_client_uri');",
+											"    pm.expect(body).to.have.property('client_secret_expires_at');",
+											"    ",
+											"    //Check expecting values",
+											"    pm.expect(body.application_type).to.eql('server');",
+											"    pm.expect(body.grant_types).to.eql(['client_credentials']);",
+											"    pm.expect(body.client_name).to.eql('test all metadatas');",
+											"    pm.expect(body.require_auth_time).to.eql(false);",
+											"    ",
+											"    //Track just created client",
+											"    pm.environment.set('newClientForDCRTests', body.id);",
+											"    pm.environment.set('newClientIdForDCRTests', body.client_id);",
+											"    pm.environment.set('newClientSecretForDCRTests', body.client_secret);",
+											"    pm.environment.set('registrationAccessToken', body.registration_access_token);",
+											"    pm.environment.set('registrationClientUri', body.registration_client_uri);",
+											"    ",
+											"    //Expect null values to not be returned.",
+											"    pm.expect(body).not.to.have.property('redirect_uris');",
+											"    pm.expect(body).not.to.have.property(\"response_types\");",
+											"    pm.expect(body).not.to.have.property('contacts');",
+											"    pm.expect(body).not.to.have.property(\"logo_uri\");",
+											"    pm.expect(body).not.to.have.property('client_uri');",
+											"    pm.expect(body).not.to.have.property(\"policy_uri\");",
+											"    pm.expect(body).not.to.have.property('tos_uri');",
+											"    pm.expect(body).not.to.have.property(\"jwks_uri\");",
+											"    pm.expect(body).not.to.have.property('sector_identifier_uri');",
+											"    pm.expect(body).not.to.have.property(\"subject_type\");",
+											"    pm.expect(body).not.to.have.property('id_token_signed_response_alg');",
+											"    pm.expect(body).not.to.have.property(\"id_token_encrypted_response_alg\");",
+											"    pm.expect(body).not.to.have.property('id_token_encrypted_response_enc');",
+											"    pm.expect(body).not.to.have.property(\"userinfo_signed_response_alg\");",
+											"    pm.expect(body).not.to.have.property('userinfo_encrypted_response_alg');",
+											"    pm.expect(body).not.to.have.property(\"userinfo_encrypted_response_enc\");",
+											"    pm.expect(body).not.to.have.property('request_object_signing_alg');",
+											"    pm.expect(body).not.to.have.property(\"request_object_encryption_alg\");",
+											"    pm.expect(body).not.to.have.property('request_object_encryption_enc');",
+											"    pm.expect(body).not.to.have.property(\"token_endpoint_auth_method\");",
+											"    pm.expect(body).not.to.have.property('token_endpoint_auth_signing_alg');",
+											"    pm.expect(body).not.to.have.property(\"default_max_age\");",
+											"    pm.expect(body).not.to.have.property(\"default_acr_values\");",
+											"    pm.expect(body).not.to.have.property(\"initiate_login_uri\");",
+											"    pm.expect(body).not.to.have.property('request_uris');",
+											"    pm.expect(body).not.to.have.property(\"scope\");",
+											"    pm.expect(body).not.to.have.property('software_id');",
+											"    pm.expect(body).not.to.have.property(\"software_version\");",
+											"    pm.expect(body).not.to.have.property(\"software_statement\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"type": "text",
+										"value": "Bearer {{access_token}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{  \n   \"redirect_uris\":null,\n   \"response_types\":null,\n   \"grant_types\":[\"client_credentials\"],\n   \"application_type\":\"server\",\n   \"contacts\":null,\n   \"client_name\":\"test all metadatas\",\n   \"logo_uri\":null,\n   \"client_uri\":null,\n   \"policy_uri\":null,\n   \"tos_uri\":null,\n   \"jwks_uri\":null,\n   \"sector_identifier_uri\":null,\n   \"subject_type\":null,\n   \"id_token_signed_response_alg\":null,\n   \"id_token_encrypted_response_alg\":null,\n   \"id_token_encrypted_response_enc\":null,\n   \"userinfo_signed_response_alg\":null,\n   \"userinfo_encrypted_response_alg\":null,\n   \"userinfo_encrypted_response_enc\":null,\n   \"request_object_signing_alg\":null,\n   \"request_object_encryption_alg\":null,\n   \"request_object_encryption_enc\":null,\n   \"token_endpoint_auth_method\":null,\n   \"token_endpoint_auth_signing_alg\":null,\n   \"default_max_age\":null,\n   \"require_auth_time\":null,\n   \"default_acr_values\":null,\n   \"initiate_login_uri\":null,\n   \"request_uris\":null,\n   \"scope\":null,\n   \"software_id\":null,\n   \"software_version\":null,\n   \"software_statement\":null\n}"
+								},
+								"url": {
+									"raw": "{{registrationEndpoint}}",
+									"host": [
+										"{{registrationEndpoint}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get client - with registration token",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Get client with response types\", function () {",
+											"    pm.response.to.be.header('Content-Type', 'application/json');",
+											"    var body = pm.response.json();",
+											"    pm.expect(body).to.have.property(\"grant_types\");",
+											"    pm.expect(body.grant_types).to.eql([ 'client_credentials' ]);",
+											"    ",
+											"    //The Authorization Server need not include the registration_access_token ",
+											"    //or registration_client_uri value in this response unless they have been updated.",
+											"    pm.expect(body).to.not.have.property('registration_access_token');",
+											"    pm.expect(body).to.not.have.property('registration_client_uri');",
+											"    ",
+											"    //Expect null values to not be returned.",
+											"    pm.expect(body).not.to.have.property('redirect_uris');",
+											"    pm.expect(body).not.to.have.property(\"response_types\");",
+											"    pm.expect(body).not.to.have.property('contacts');",
+											"    pm.expect(body).not.to.have.property(\"logo_uri\");",
+											"    pm.expect(body).not.to.have.property('client_uri');",
+											"    pm.expect(body).not.to.have.property(\"policy_uri\");",
+											"    pm.expect(body).not.to.have.property('tos_uri');",
+											"    pm.expect(body).not.to.have.property(\"jwks_uri\");",
+											"    pm.expect(body).not.to.have.property('sector_identifier_uri');",
+											"    pm.expect(body).not.to.have.property(\"subject_type\");",
+											"    pm.expect(body).not.to.have.property('id_token_signed_response_alg');",
+											"    pm.expect(body).not.to.have.property(\"id_token_encrypted_response_alg\");",
+											"    pm.expect(body).not.to.have.property('id_token_encrypted_response_enc');",
+											"    pm.expect(body).not.to.have.property(\"userinfo_signed_response_alg\");",
+											"    pm.expect(body).not.to.have.property('userinfo_encrypted_response_alg');",
+											"    pm.expect(body).not.to.have.property(\"userinfo_encrypted_response_enc\");",
+											"    pm.expect(body).not.to.have.property('request_object_signing_alg');",
+											"    pm.expect(body).not.to.have.property(\"request_object_encryption_alg\");",
+											"    pm.expect(body).not.to.have.property('request_object_encryption_enc');",
+											"    pm.expect(body).not.to.have.property(\"token_endpoint_auth_method\");",
+											"    pm.expect(body).not.to.have.property('token_endpoint_auth_signing_alg');",
+											"    pm.expect(body).not.to.have.property(\"default_max_age\");",
+											"    pm.expect(body).not.to.have.property(\"default_acr_values\");",
+											"    pm.expect(body).not.to.have.property(\"initiate_login_uri\");",
+											"    pm.expect(body).not.to.have.property('request_uris');",
+											"    pm.expect(body).not.to.have.property(\"scope\");",
+											"    pm.expect(body).not.to.have.property('software_id');",
+											"    pm.expect(body).not.to.have.property(\"software_version\");",
+											"    pm.expect(body).not.to.have.property(\"software_statement\");",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"type": "text",
+										"value": "Bearer {{registrationAccessToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{registrationClientUri}}",
+									"host": [
+										"{{registrationClientUri}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Patch client - with registration token",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Get client with response types\", function () {",
+											"    pm.response.to.be.header('Content-Type', 'application/json');",
+											"    var body = pm.response.json();",
+											"    //Check expecting metadata",
+											"    pm.expect(body).to.have.property('grant_types');",
+											"    pm.expect(body).to.have.property('application_type');",
+											"    pm.expect(body).to.have.property('client_name');",
+											"    pm.expect(body).to.have.property('require_auth_time');",
+											"    pm.expect(body).to.have.property('client_id');",
+											"    pm.expect(body).to.have.property('client_secret');",
+											"    pm.expect(body).to.have.property('registration_access_token');",
+											"    pm.expect(body).to.have.property('registration_client_uri');",
+											"    pm.expect(body).to.have.property('client_secret_expires_at');",
+											"    ",
+											"    //Check expecting values",
+											"    pm.expect(body.application_type).to.eql('server');",
+											"    pm.expect(body.grant_types).to.eql(['client_credentials']);",
+											"    pm.expect(body.client_name).to.eql('test');",
+											"    pm.expect(body.require_auth_time).to.eql(false);",
+											"    ",
+											"    //Expect null values to not be returned.",
+											"    pm.expect(body).not.to.have.property('redirect_uris');",
+											"    pm.expect(body).not.to.have.property(\"response_types\");",
+											"    pm.expect(body).not.to.have.property('contacts');",
+											"    pm.expect(body).not.to.have.property(\"logo_uri\");",
+											"    pm.expect(body).not.to.have.property('client_uri');",
+											"    pm.expect(body).not.to.have.property(\"policy_uri\");",
+											"    pm.expect(body).not.to.have.property('tos_uri');",
+											"    pm.expect(body).not.to.have.property(\"jwks_uri\");",
+											"    pm.expect(body).not.to.have.property('sector_identifier_uri');",
+											"    pm.expect(body).not.to.have.property(\"subject_type\");",
+											"    pm.expect(body).not.to.have.property('id_token_signed_response_alg');",
+											"    pm.expect(body).not.to.have.property(\"id_token_encrypted_response_alg\");",
+											"    pm.expect(body).not.to.have.property('id_token_encrypted_response_enc');",
+											"    pm.expect(body).not.to.have.property(\"userinfo_signed_response_alg\");",
+											"    pm.expect(body).not.to.have.property('userinfo_encrypted_response_alg');",
+											"    pm.expect(body).not.to.have.property(\"userinfo_encrypted_response_enc\");",
+											"    pm.expect(body).not.to.have.property('request_object_signing_alg');",
+											"    pm.expect(body).not.to.have.property(\"request_object_encryption_alg\");",
+											"    pm.expect(body).not.to.have.property('request_object_encryption_enc');",
+											"    pm.expect(body).not.to.have.property(\"token_endpoint_auth_method\");",
+											"    pm.expect(body).not.to.have.property('token_endpoint_auth_signing_alg');",
+											"    pm.expect(body).not.to.have.property(\"default_max_age\");",
+											"    pm.expect(body).not.to.have.property(\"default_acr_values\");",
+											"    pm.expect(body).not.to.have.property(\"initiate_login_uri\");",
+											"    pm.expect(body).not.to.have.property('request_uris');",
+											"    pm.expect(body).not.to.have.property(\"scope\");",
+											"    pm.expect(body).not.to.have.property('software_id');",
+											"    pm.expect(body).not.to.have.property(\"software_version\");",
+											"    pm.expect(body).not.to.have.property(\"software_statement\");",
+											"});",
+											"",
+											"pm.test(\"One time Token\", function() {",
+											"    var body = pm.response.json();",
+											"    pm.expect(body).to.have.property('registration_access_token');",
+											"    pm.expect(body.registration_access_token).to.not.eql(pm.environment.get('registrationAccessToken'));",
+											"    pm.environment.set('registrationAccessToken', body.registration_access_token);",
+											"    pm.environment.set('registrationClientUri', body.registration_client_uri);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"type": "text",
+										"value": "Bearer {{registrationAccessToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{  \n   \"redirect_uris\":null,\n   \"response_types\":null,\n   \"grant_types\":[\"client_credentials\"],\n   \"application_type\":\"server\",\n   \"contacts\":null,\n   \"client_name\":\"test\",\n   \"logo_uri\":null,\n   \"client_uri\":null,\n   \"policy_uri\":null,\n   \"tos_uri\":null,\n   \"jwks_uri\":null,\n   \"sector_identifier_uri\":null,\n   \"subject_type\":null,\n   \"id_token_signed_response_alg\":null,\n   \"id_token_encrypted_response_alg\":null,\n   \"id_token_encrypted_response_enc\":null,\n   \"userinfo_signed_response_alg\":null,\n   \"userinfo_encrypted_response_alg\":null,\n   \"userinfo_encrypted_response_enc\":null,\n   \"request_object_signing_alg\":null,\n   \"request_object_encryption_alg\":null,\n   \"request_object_encryption_enc\":null,\n   \"token_endpoint_auth_method\":null,\n   \"token_endpoint_auth_signing_alg\":null,\n   \"default_max_age\":null,\n   \"require_auth_time\":null,\n   \"default_acr_values\":null,\n   \"initiate_login_uri\":null,\n   \"request_uris\":null,\n   \"scope\":null,\n   \"software_id\":null,\n   \"software_version\":null,\n   \"software_statement\":null\n}"
+								},
+								"url": {
+									"raw": "{{registrationClientUri}}",
+									"host": [
+										"{{registrationClientUri}}"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Update client - with registration token",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
+										"exec": [
+											"pm.test(\"Status code is 200\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Get client with response types\", function () {",
+											"    pm.response.to.be.header('Content-Type', 'application/json');",
+											"    var body = pm.response.json();",
+											"    //Check expecting metadata",
+											"    pm.expect(body).to.have.property('grant_types');",
+											"    pm.expect(body).to.have.property('application_type');",
+											"    pm.expect(body).to.have.property('client_name');",
+											"    pm.expect(body).to.have.property('require_auth_time');",
+											"    pm.expect(body).to.have.property('client_id');",
+											"    pm.expect(body).to.have.property('client_secret');",
+											"    pm.expect(body).to.have.property('registration_access_token');",
+											"    pm.expect(body).to.have.property('registration_client_uri');",
+											"    pm.expect(body).to.have.property('client_secret_expires_at');",
+											"    ",
+											"    //Check expecting values",
+											"    pm.expect(body.application_type).to.eql('server');",
+											"    pm.expect(body.grant_types).to.eql(['client_credentials']);",
+											"    pm.expect(body.client_name).to.eql('test');",
+											"    pm.expect(body.require_auth_time).to.eql(false);",
+											"    ",
+											"    //Expect null values to not be returned.",
+											"    pm.expect(body).not.to.have.property('redirect_uris');",
+											"    pm.expect(body).not.to.have.property(\"response_types\");",
+											"    pm.expect(body).not.to.have.property('contacts');",
+											"    pm.expect(body).not.to.have.property(\"logo_uri\");",
+											"    pm.expect(body).not.to.have.property('client_uri');",
+											"    pm.expect(body).not.to.have.property(\"policy_uri\");",
+											"    pm.expect(body).not.to.have.property('tos_uri');",
+											"    pm.expect(body).not.to.have.property(\"jwks_uri\");",
+											"    pm.expect(body).not.to.have.property('sector_identifier_uri');",
+											"    pm.expect(body).not.to.have.property(\"subject_type\");",
+											"    pm.expect(body).not.to.have.property('id_token_signed_response_alg');",
+											"    pm.expect(body).not.to.have.property(\"id_token_encrypted_response_alg\");",
+											"    pm.expect(body).not.to.have.property('id_token_encrypted_response_enc');",
+											"    pm.expect(body).not.to.have.property(\"userinfo_signed_response_alg\");",
+											"    pm.expect(body).not.to.have.property('userinfo_encrypted_response_alg');",
+											"    pm.expect(body).not.to.have.property(\"userinfo_encrypted_response_enc\");",
+											"    pm.expect(body).not.to.have.property('request_object_signing_alg');",
+											"    pm.expect(body).not.to.have.property(\"request_object_encryption_alg\");",
+											"    pm.expect(body).not.to.have.property('request_object_encryption_enc');",
+											"    pm.expect(body).not.to.have.property(\"token_endpoint_auth_method\");",
+											"    pm.expect(body).not.to.have.property('token_endpoint_auth_signing_alg');",
+											"    pm.expect(body).not.to.have.property(\"default_max_age\");",
+											"    pm.expect(body).not.to.have.property(\"default_acr_values\");",
+											"    pm.expect(body).not.to.have.property(\"initiate_login_uri\");",
+											"    pm.expect(body).not.to.have.property('request_uris');",
+											"    pm.expect(body).not.to.have.property(\"scope\");",
+											"    pm.expect(body).not.to.have.property('software_id');",
+											"    pm.expect(body).not.to.have.property(\"software_version\");",
+											"    pm.expect(body).not.to.have.property(\"software_statement\");",
+											"});",
+											"",
+											"pm.test(\"One time Token\", function() {",
+											"    var body = pm.response.json();",
+											"    pm.expect(body).to.have.property('registration_access_token');",
+											"    pm.expect(body.registration_access_token).to.not.eql(pm.environment.get('registrationAccessToken'));",
+											"    pm.environment.set('registrationAccessToken', body.registration_access_token);",
+											"    pm.environment.set('registrationClientUri', body.registration_client_uri);",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "Authorization",
+										"type": "text",
+										"value": "Bearer {{registrationAccessToken}}"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{  \n   \"redirect_uris\":null,\n   \"response_types\":null,\n   \"grant_types\":[\"client_credentials\"],\n   \"application_type\":\"server\",\n   \"contacts\":null,\n   \"client_name\":\"test\",\n   \"logo_uri\":null,\n   \"client_uri\":null,\n   \"policy_uri\":null,\n   \"tos_uri\":null,\n   \"jwks_uri\":null,\n   \"sector_identifier_uri\":null,\n   \"subject_type\":null,\n   \"id_token_signed_response_alg\":null,\n   \"id_token_encrypted_response_alg\":null,\n   \"id_token_encrypted_response_enc\":null,\n   \"userinfo_signed_response_alg\":null,\n   \"userinfo_encrypted_response_alg\":null,\n   \"userinfo_encrypted_response_enc\":null,\n   \"request_object_signing_alg\":null,\n   \"request_object_encryption_alg\":null,\n   \"request_object_encryption_enc\":null,\n   \"token_endpoint_auth_method\":null,\n   \"token_endpoint_auth_signing_alg\":null,\n   \"default_max_age\":null,\n   \"require_auth_time\":null,\n   \"default_acr_values\":null,\n   \"initiate_login_uri\":null,\n   \"request_uris\":null,\n   \"scope\":null,\n   \"software_id\":null,\n   \"software_version\":null,\n   \"software_statement\":null\n}"
+								},
+								"url": {
+									"raw": "{{registrationClientUri}}",
+									"host": [
+										"{{registrationClientUri}}"
 									]
 								}
 							},
@@ -48791,6 +49347,460 @@
 				},
 				{
 					"name": "Delete client",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
+								"exec": [
+									"pm.test(\"Status code is 204\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"type": "text",
+								"value": "Bearer {{registrationAccessToken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "{{registrationClientUri}}",
+							"host": [
+								"{{registrationClientUri}}"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Case - Default and Allowed Scopes",
+			"item": [
+				{
+					"name": "Enable Default and Allowed scopes",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "bfe78ac1-144a-4bbd-abf9-55e160e723bf",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"DCR enabled for domain\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.oidc.clientRegistrationSettings.isAllowedScopesEnabled).to.eql(true);",
+									"    pm.expect(jsonData.oidc.clientRegistrationSettings.allowedScopes).to.eql([\"email\"]);",
+									"    pm.expect(jsonData.oidc.clientRegistrationSettings.defaultScopes).to.eql([\"openid\",\"profile\"]);",
+									"});",
+									"",
+									"// wait for sync process",
+									"setTimeout(function(){}, 5000);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"oidc\": {\n    \"clientRegistrationSettings\": {\n      \"isAllowedScopesEnabled\": true,\n      \"allowedScopes\" : [\n\t\t\"email\"\n\t  ],\n\t  \"defaultScopes\" : [\n\t\t\"openid\",\n\t\t\"profile\"\n\t  ]\n    }\n  }\n}"
+						},
+						"url": {
+							"raw": "{{management_url}}/management/domains/{{domain}}",
+							"host": [
+								"{{management_url}}"
+							],
+							"path": [
+								"management",
+								"domains",
+								"{{domain}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Allowed Scopes filter - scopes reduced",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
+								"exec": [
+									"pm.test(\"Status code is 201\", function () {",
+									"    pm.response.to.have.status(201);",
+									"});",
+									"",
+									"pm.test(\"Has default attributes\", function () {",
+									"    var body = pm.response.json();",
+									"    pm.expect(body).to.have.property('scope');",
+									"    pm.expect(body.scope).to.eql('email');//scopes have been filtered to keep only allowed ones",
+									"",
+									"    pm.environment.set('newClientForDCRTests', body.id);",
+									"    pm.environment.set('newClientIdForDCRTests', body.client_id);",
+									"    pm.environment.set('newClientSecretForDCRTests', body.client_secret);",
+									"    pm.environment.set('registrationAccessToken', body.registration_access_token);",
+									"    pm.environment.set('registrationClientUri', body.registration_client_uri);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"type": "text",
+								"value": "Bearer {{access_token}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n   \"redirect_uris\":\n     [\"https://client.example.org/callback\",\n      \"https://client.example.org/callback2\"],\n   \"scope\": \"phone email\"\n  }"
+						},
+						"url": {
+							"raw": "{{registrationEndpoint}}",
+							"host": [
+								"{{registrationEndpoint}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "All scopes rejected - Default scopes applied",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Get client with response types\", function () {",
+									"    pm.response.to.be.header('Content-Type', 'application/json');",
+									"    var body = pm.response.json();",
+									"",
+									"    pm.expect(body).to.have.property('scope');",
+									"    pm.expect(body.scope).to.eql('openid profile');//no scopes retained, expecting default scopes.",
+									"});",
+									"",
+									"pm.test(\"One time Token\", function() {",
+									"    var body = pm.response.json();",
+									"    pm.expect(body).to.have.property('registration_access_token');",
+									"    pm.expect(body.registration_access_token).to.not.eql(pm.environment.get('registrationAccessToken'));",
+									"    pm.environment.set('registrationAccessToken', body.registration_access_token);",
+									"    pm.environment.set('registrationClientUri', body.registration_client_uri);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"type": "text",
+								"value": "Bearer {{registrationAccessToken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n   \"scope\": \"phone address\"\n}"
+						},
+						"url": {
+							"raw": "{{registrationClientUri}}",
+							"host": [
+								"{{registrationClientUri}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Reset scope to email",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Get client with response types\", function () {",
+									"    pm.response.to.be.header('Content-Type', 'application/json');",
+									"    var body = pm.response.json();",
+									"",
+									"    pm.expect(body).to.have.property('scope');",
+									"    pm.expect(body.scope).to.eql('email');",
+									"});",
+									"",
+									"pm.test(\"One time Token\", function() {",
+									"    var body = pm.response.json();",
+									"    pm.expect(body).to.have.property('registration_access_token');",
+									"    pm.expect(body.registration_access_token).to.not.eql(pm.environment.get('registrationAccessToken'));",
+									"    pm.environment.set('registrationAccessToken', body.registration_access_token);",
+									"    pm.environment.set('registrationClientUri', body.registration_client_uri);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"type": "text",
+								"value": "Bearer {{registrationAccessToken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n   \"scope\": \"email\"\n}"
+						},
+						"url": {
+							"raw": "{{registrationClientUri}}",
+							"host": [
+								"{{registrationClientUri}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "No scopes - Default scopes applied",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Get client with response types\", function () {",
+									"    pm.response.to.be.header('Content-Type', 'application/json');",
+									"    var body = pm.response.json();",
+									"    pm.expect(body.client_name).to.eql('Client name updated via DCR');",
+									"    pm.expect(body.scope).to.eql('openid profile');//no scopes into the request, expecting default scopes.",
+									"});",
+									"",
+									"pm.test(\"One time Token\", function() {",
+									"    var body = pm.response.json();",
+									"    pm.expect(body).to.have.property('registration_access_token');",
+									"    pm.expect(body.registration_access_token).to.not.eql(pm.environment.get('registrationAccessToken'));",
+									"    pm.environment.set('registrationAccessToken', body.registration_access_token);",
+									"    pm.environment.set('registrationClientUri', body.registration_client_uri);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"type": "text",
+								"value": "Bearer {{registrationAccessToken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"redirect_uris\": [\n        \"https://client.example.org/callback\",\n        \"https://client.example.org/callback2\"\n    ],\n    \"response_types\": [\n        \"code\"\n    ],\n    \"grant_types\": [\n        \"authorization_code\"\n    ],\n    \"application_type\": \"web\",\n    \"contacts\": [\n        \"marie@example.org\",\n        \"jeanne@example.org\"\n    ],\n\t\"client_name\": \"Client name updated via DCR\",\n    \"logo_uri\": \"https://client.example.org/logo.png\",\n    \"subject_type\": \"public\",\n    \"userinfo_encrypted_response_alg\": \"RSA-OAEP-256\",\n    \"userinfo_encrypted_response_enc\": \"A128CBC-HS256\",\n    \"token_endpoint_auth_method\": \"client_secret_basic\",\n    \"require_auth_time\": false,\n    \"request_uris\": [\n        \"https://client.example.org/rf.txt#qpXaRLh_n93TTR9F252ValdatUQvQiJi5BDub2BeznA\"\n    ]\n}"
+						},
+						"url": {
+							"raw": "{{registrationClientUri}}",
+							"host": [
+								"{{registrationClientUri}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Reset scope to email",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Get client with response types\", function () {",
+									"    pm.response.to.be.header('Content-Type', 'application/json');",
+									"    var body = pm.response.json();",
+									"",
+									"    pm.expect(body).to.have.property('scope');",
+									"    pm.expect(body.scope).to.eql('email');",
+									"});",
+									"",
+									"pm.test(\"One time Token\", function() {",
+									"    var body = pm.response.json();",
+									"    pm.expect(body).to.have.property('registration_access_token');",
+									"    pm.expect(body.registration_access_token).to.not.eql(pm.environment.get('registrationAccessToken'));",
+									"    pm.environment.set('registrationAccessToken', body.registration_access_token);",
+									"    pm.environment.set('registrationClientUri', body.registration_client_uri);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"type": "text",
+								"value": "Bearer {{registrationAccessToken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n   \"scope\": \"email\"\n}"
+						},
+						"url": {
+							"raw": "{{registrationClientUri}}",
+							"host": [
+								"{{registrationClientUri}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Scopes null - Default scopes applied",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "d83b2401-3844-4147-bbb3-abe08b43a342",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Get client with response types\", function () {",
+									"    pm.response.to.be.header('Content-Type', 'application/json');",
+									"    var body = pm.response.json();",
+									"",
+									"    pm.expect(body).to.have.property('scope');",
+									"    pm.expect(body.scope).to.eql('openid profile');//no scopes retained, expecting default scopes.",
+									"});",
+									"",
+									"pm.test(\"One time Token\", function() {",
+									"    var body = pm.response.json();",
+									"    pm.expect(body).to.have.property('registration_access_token');",
+									"    pm.expect(body.registration_access_token).to.not.eql(pm.environment.get('registrationAccessToken'));",
+									"    pm.environment.set('registrationAccessToken', body.registration_access_token);",
+									"    pm.environment.set('registrationClientUri', body.registration_client_uri);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"type": "text",
+								"value": "Bearer {{registrationAccessToken}}"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n   \"scope\": null\n}"
+						},
+						"url": {
+							"raw": "{{registrationClientUri}}",
+							"host": [
+								"{{registrationClientUri}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete client - with registration token",
 					"event": [
 						{
 							"listen": "test",


### PR DESCRIPTION
This is the last part of issue [#2326](https://github.com/gravitee-io/issues/issues/2326)
Give the possibility to limit scopes on the Dynamic Client Registration endpoint.
Give the possibility to apply some defaut scopes _(when no scopes are requested)_