### PR TITLE
Always enhance request with users permissions if required

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/request/AbstractRequestResolver.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/request/AbstractRequestResolver.java
@@ -76,23 +76,19 @@ public abstract class AbstractRequestResolver<R extends OAuth2Request> {
                         .map(role -> role.getPermissions() != null ? role.getPermissions() : Collections.<String>emptyList())
                         .flatMap(List::stream)
                         .collect(Collectors.toSet());
-                // no requested scope, set default user permissions scopes to the request
-                if (requestScopes == null || requestScopes.isEmpty()) {
-                    resolvedScopes.addAll(new HashSet<>(permissions));
-                } else {
-                    // filter the actual scopes granted by the resource owner
+                
+                if (requestScopes != null) {
+                	// filter the actual scopes granted by the resource owner
                     requestScopes.forEach(scope -> {
-                        if (permissions.contains(scope)) {
-                            // scope can be rejected by the client but approved by the resource owner
-                            resolvedScopes.add(scope);
-                            invalidScopes.remove(scope);
-                        } else {
-                            if (!clientResolvedScopes.contains(scope)) {
-                                invalidScopes.add(scope);
-                            }
+                        if (!permissions.contains(scope) && !clientResolvedScopes.contains(scope)) {
+                        	invalidScopes.add(scope);
                         }
                     });
                 }
+                
+                // The request must be enhanced with all of user's permissions
+                invalidScopes.removeAll(permissions);
+                resolvedScopes.addAll(permissions);
             }
         }
 


### PR DESCRIPTION
This PR fixes Access Management issue https://github.com/gravitee-io/issues/issues/2958.

Sopes related to user's permissions are always granted when the client is configured with option "Enhance scopes" (that is if `client.isEnhanceScopesWithUserPermissions() == true`).

Related test cases are included in this PR.