### PR TITLE
Fix users search pagination in Management API

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-handlers/gravitee-am-management-api-handlers-management/src/main/java/io/gravitee/am/management/handlers/management/api/resources/UsersResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-handlers/gravitee-am-management-api-handlers-management/src/main/java/io/gravitee/am/management/handlers/management/api/resources/UsersResource.java
@@ -82,7 +82,7 @@ public class UsersResource extends AbstractResource {
                 .switchIfEmpty(Maybe.error(new DomainNotFoundException(domain)))
                 .flatMapSingle(irrelevant -> {
                     if (query != null) {
-                        return userService.search(domain, query, Integer.min(size, MAX_USERS_SIZE_PER_PAGE));
+                        return userService.search(domain, query, page, Integer.min(size, MAX_USERS_SIZE_PER_PAGE));
                     } else {
                         return userService.findByDomain(domain, page, Integer.min(size, MAX_USERS_SIZE_PER_PAGE));
                     }

--- a/gravitee-am-management-api/gravitee-am-management-api-repository/src/main/java/io/gravitee/am/management/repository/proxy/UserRepositoryProxy.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-repository/src/main/java/io/gravitee/am/management/repository/proxy/UserRepositoryProxy.java
@@ -44,8 +44,8 @@ public class UserRepositoryProxy extends AbstractProxy<UserRepository> implement
     }
 
     @Override
-    public Single<Page<User>> search(String domain, String query, int limit) {
-        return target.search(domain, query, limit);
+    public Single<Page<User>> search(String domain, String query, int page, int size) {
+        return target.search(domain, query, page, size);
     }
 
     @Override

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/UserService.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/UserService.java
@@ -31,7 +31,7 @@ import java.util.List;
  */
 public interface UserService {
 
-    Single<Page<User>> search(String domain, String query, int limit);
+    Single<Page<User>> search(String domain, String query, int page, int size);
 
     Single<Page<User>> findByDomain(String domain, int page, int size);
 

--- a/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/UserServiceImpl.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-service/src/main/java/io/gravitee/am/management/service/impl/UserServiceImpl.java
@@ -100,8 +100,8 @@ public class UserServiceImpl implements UserService {
     private RoleService roleService;
 
     @Override
-    public Single<Page<User>> search(String domain, String query, int limit) {
-        return userService.search(domain, query, limit);
+    public Single<Page<User>> search(String domain, String query, int page, int size) {
+        return userService.search(domain, query, page, size);
     }
 
     @Override

--- a/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/UserRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-api/src/main/java/io/gravitee/am/repository/management/api/UserRepository.java
@@ -34,7 +34,7 @@ public interface UserRepository extends CrudRepository<User, String> {
 
     Single<Page<User>> findByDomain(String domain, int page, int size);
 
-    Single<Page<User>> search(String domain, String query, int limit);
+    Single<Page<User>> search(String domain, String query, int page, int size);
 
     Single<List<User>> findByDomainAndEmail(String domain, String email, boolean strict);
 

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoUserRepository.java
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/src/main/java/io/gravitee/am/repository/mongodb/management/MongoUserRepository.java
@@ -84,7 +84,7 @@ public class MongoUserRepository extends AbstractManagementMongoRepository imple
     }
 
     @Override
-    public Single<Page<User>> search(String domain, String query, int limit) {
+    public Single<Page<User>> search(String domain, String query, int page, int size) {
         // currently search on username field
         Bson searchQuery = new BasicDBObject(FIELD_USERNAME, query);
         // if query contains wildcard, use the regex query
@@ -99,7 +99,7 @@ public class MongoUserRepository extends AbstractManagementMongoRepository imple
                 searchQuery);
 
         Single<Long> countOperation = Observable.fromPublisher(usersCollection.countDocuments(mongoQuery)).first(0l);
-        Single<Set<User>> usersOperation = Observable.fromPublisher(usersCollection.find(mongoQuery).limit(limit)).map(this::convert).collect(LinkedHashSet::new, Set::add);
+        Single<Set<User>> usersOperation = Observable.fromPublisher(usersCollection.find(mongoQuery).skip(size * page).limit(size)).map(this::convert).collect(LinkedHashSet::new, Set::add);
         return Single.zip(countOperation, usersOperation, (count, users) -> new Page<>(users, 0, count));
     }
 

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/UserService.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/UserService.java
@@ -37,7 +37,7 @@ public interface UserService {
 
     Single<Page<User>> findByDomain(String domain, int page, int size);
 
-    Single<Page<User>> search(String domain, String query, int limit);
+    Single<Page<User>> search(String domain, String query, int page, int size);
 
     Single<List<User>> findByIdIn(List<String> ids);
 

--- a/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/UserServiceImpl.java
+++ b/gravitee-am-service/src/main/java/io/gravitee/am/service/impl/UserServiceImpl.java
@@ -80,9 +80,9 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public Single<Page<User>> search(String domain, String query, int limit) {
+    public Single<Page<User>> search(String domain, String query, int page, int size) {
         LOGGER.debug("Search users for domain {} with query {}", domain, query);
-        return userRepository.search(domain, query, limit)
+        return userRepository.search(domain, query, page, size)
                 .onErrorResumeNext(ex -> {
                     LOGGER.error("An error occurs while trying to search users for domain {} and query {}", domain, query, ex);
                     return Single.error(new TechnicalManagementException(String.format("An error occurs while trying to find users for domain %s and query %s", domain, query), ex));


### PR DESCRIPTION
This PR fixes issue https://github.com/gravitee-io/issues/issues/2994 by taking into account the page parameter in the users list endpoint of the Management API not only for users listing but also for searching (when parameter `q` is passed).

The actual fix is in the MongoDB query: call to `skip()` was missing in class `MongoDbRepository`. The rest are simply adaptations of methods signatures, in order to pass the `page` parameter from the endpoint to the query.

Added also a test case to check the correctness of paginated results.