### PR TITLE
Add invalid password message on registration_confirmation.html

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/registration_confirmation.html
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/resources/webroot/views/registration_confirmation.html
@@ -25,6 +25,9 @@
                 <label>Hi <span th:text="${user.firstName} + ' ' + ${user.lastName}"></span></label>
                 <p>Thanks for signing up, please complete the form to activate your account</p>
             </div>
+            <div th:if="${warning}" class="registration-confirmation-error-info">
+                <p>Invalid password value. It does not comply with the password policy.</p>
+            </div>
             <form role="form" th:action="@{confirmRegistration}" method="post" style="display: flex; flex-direction: column; margin-top: 30px;">
                 <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label" style="width: 100%; display: flex;">
                     <input class="mdl-textfield__input" type="password" id="password" name="password"/>

--- a/gravitee-am-ui/src/app/domain/components/forms/form/dialog/form-info.component.html
+++ b/gravitee-am-ui/src/app/domain/components/forms/form/dialog/form-info.component.html
@@ -183,6 +183,9 @@
               <label>Hi <span th:text="${user.firstName} + ' ' + ${user.lastName}"></span></label>
               <p>Thanks for signing up, please complete the form to activate your account</p>
             </div>
+            <div th:if="${warning}">
+                <p>Invalid password value. It does not comply with the password policy.</p>
+            </div>
             <form th:action="@{confirmRegistration}" method="post">
               <input type="password" id="password" name="password" required/>
               <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>


### PR DESCRIPTION
…when query parameter `warning` is present.
Add the same message in form-info.component.html in REGISTRATION_CONFIRMATION raw template.

Closes [gravitee-io/issues#3057](https://github.com/gravitee-io/issues/issues/3057)