### PR TITLE
fix:snapshot_dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,4 +239,13 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <!-- Allow oss snapshot without requiring the developer to add it into it's own maven settings.xml -->
+    <repositories>
+        <repository>
+            <id>snapshots-repo</id>
+            <name>snapshots repository</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </repository>
+    </repositories>
 </project>


### PR DESCRIPTION
After an update of the master, I was unable to build the project due to unresolved dependencies.  
After checking, the root cause was due to snapshot dependencies.  

Instead of asking developers to add them into their maven settings.xml, I think this is more developer-friendly to add the repository directly on your pom.xml as done into this PR.

Regards,
Alexandre.