### PR TITLE
fix(ui): display domain activation banner only when user has permission

### DIFF
--- a/gravitee-am-ui/src/app/domain/domain.component.html
+++ b/gravitee-am-ui/src/app/domain/domain.component.html
@@ -16,7 +16,7 @@
 
 -->
 <div fxLayout="column">
-  <mat-card class="domain-banner" *ngIf="!domain.enabled">
+  <mat-card class="domain-banner" *ngIf="!domain.enabled && hasPermissions(['domain_settings_update'])">
     <mat-icon>warning</mat-icon>
     <p class="domain-banner-text"><strong>{{domain.name}}</strong> domain is disabled, <span (click)="enable()">click here</span> to enable the domain.</p>
   </mat-card>

--- a/gravitee-am-ui/src/app/domain/domain.component.ts
+++ b/gravitee-am-ui/src/app/domain/domain.component.ts
@@ -76,6 +76,10 @@ export class DomainComponent implements OnInit {
     });
   }
 
+  private hasPermissions(permissions): boolean{
+    return this.authService.hasPermissions(permissions);
+  }
+
   private canNavigate(permissions): boolean {
     return this.authService.hasPermissions(permissions);
   }


### PR DESCRIPTION
Closes gravitee-io/issues#3432