### PR TITLE
feat(grant): enhance user on ExtensionGrant to get dynamic scopes

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/granter/extensiongrant/ExtensionGrantGranter.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/granter/extensiongrant/ExtensionGrantGranter.java
@@ -20,6 +20,7 @@ import io.gravitee.am.common.oidc.idtoken.Claims;
 import io.gravitee.am.extensiongrant.api.ExtensionGrantProvider;
 import io.gravitee.am.gateway.handler.common.auth.UserAuthenticationManager;
 import io.gravitee.am.gateway.handler.common.auth.idp.IdentityProviderManager;
+import io.gravitee.am.gateway.handler.common.user.UserService;
 import io.gravitee.am.gateway.handler.oauth2.exception.InvalidGrantException;
 import io.gravitee.am.gateway.handler.oauth2.exception.UnauthorizedClientException;
 import io.gravitee.am.gateway.handler.oauth2.service.granter.AbstractTokenGranter;
@@ -55,6 +56,7 @@ public class ExtensionGrantGranter extends AbstractTokenGranter {
     private final ExtensionGrant extensionGrant;
     private final UserAuthenticationManager userAuthenticationManager;
     private final IdentityProviderManager identityProviderManager;
+    private final UserService userService;
     private Date minDate;
 
     public ExtensionGrantGranter(ExtensionGrantProvider extensionGrantProvider,
@@ -62,7 +64,8 @@ public class ExtensionGrantGranter extends AbstractTokenGranter {
                                  UserAuthenticationManager userAuthenticationManager,
                                  TokenService tokenService,
                                  TokenRequestResolver tokenRequestResolver,
-                                 IdentityProviderManager identityProviderManager) {
+                                 IdentityProviderManager identityProviderManager,
+                                 UserService userService) {
         super(extensionGrant.getGrantType());
         setTokenService(tokenService);
         setTokenRequestResolver(tokenRequestResolver);
@@ -71,6 +74,7 @@ public class ExtensionGrantGranter extends AbstractTokenGranter {
         this.extensionGrant = extensionGrant;
         this.userAuthenticationManager = userAuthenticationManager;
         this.identityProviderManager = identityProviderManager;
+        this.userService = userService;
     }
 
     @Override
@@ -124,6 +128,7 @@ public class ExtensionGrantGranter extends AbstractTokenGranter {
                                         user.setRoles(idpUser.getRoles());
                                         return user;
                                     })
+                                    .flatMap(user -> userService.enhance(user).toMaybe())
                                     .switchIfEmpty(Maybe.error(new InvalidGrantException("Unknown user: " + endUser.getId())));
                         } else {
                             User user = new User();

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/granter/extensiongrant/impl/ExtensionGrantManagerImpl.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/granter/extensiongrant/impl/ExtensionGrantManagerImpl.java
@@ -20,6 +20,7 @@ import io.gravitee.am.common.event.EventManager;
 import io.gravitee.am.common.event.ExtensionGrantEvent;
 import io.gravitee.am.gateway.handler.common.auth.UserAuthenticationManager;
 import io.gravitee.am.gateway.handler.common.auth.idp.IdentityProviderManager;
+import io.gravitee.am.gateway.handler.common.user.UserService;
 import io.gravitee.am.gateway.handler.oauth2.service.granter.CompositeTokenGranter;
 import io.gravitee.am.gateway.handler.oauth2.service.granter.TokenGranter;
 import io.gravitee.am.gateway.handler.oauth2.service.granter.extensiongrant.ExtensionGrantGranter;
@@ -81,6 +82,9 @@ public class ExtensionGrantManagerImpl extends AbstractService implements Extens
 
     @Autowired
     private EventManager eventManager;
+    
+    @Autowired
+    private UserService userService;
 
     @Override
     public void afterPropertiesSet() {
@@ -163,7 +167,7 @@ public class ExtensionGrantManagerImpl extends AbstractService implements Extens
             }
             ExtensionGrantProvider extensionGrantProvider = extensionGrantPluginManager.create(extensionGrant.getType(), extensionGrant.getConfiguration(), authenticationProvider);
             ExtensionGrantGranter extensionGrantGranter = new ExtensionGrantGranter(extensionGrantProvider, extensionGrant,
-                    userAuthenticationManager, tokenService, tokenRequestResolver, identityProviderManager);
+                    userAuthenticationManager, tokenService, tokenRequestResolver, identityProviderManager, userService);
             // backward compatibility, set min date to the extension grant granter to choose the good one for the old clients
             extensionGrantGranter.setMinDate(minDate);
             ((CompositeTokenGranter) tokenGranter).addTokenGranter(extensionGrant.getId(), extensionGrantGranter);


### PR DESCRIPTION
In the case of ExtensionGrantGranter.resolveResourceOwner the user's roles permissions are not loaded, whereas we expect them to be added to user's scope.
These permissions/scopes are well loaded by AuthorizationCodeGranter or RefreshTokenGranter for example.

_An other solution that the one proposed could be to modify the AbstractTokenGranter grant method but it didn't seem relevant as the issue is only on extension grant._
