### PR TITLE
Fix AM management api OpenApi descriptor

### DIFF
--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/OrganizationResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/OrganizationResource.java
@@ -87,11 +87,6 @@ public class OrganizationResource extends AbstractResource {
         return resourceContext.getResource(EnvironmentsResource.class);
     }
 
-    @Path("plugins")
-    public PluginsResource getPluginsResource() {
-        return resourceContext.getResource(PluginsResource.class);
-    }
-
     @Path("audits")
     public AuditsResource getAuditsResource() {
         return resourceContext.getResource(AuditsResource.class);

--- a/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/FactorResource.java
+++ b/gravitee-am-management-api/gravitee-am-management-api-rest/src/main/java/io/gravitee/am/management/handlers/management/api/resources/organizations/environments/domains/FactorResource.java
@@ -105,7 +105,7 @@ public class FactorResource extends AbstractResource {
             @PathParam("organizationId") String organizationId,
             @PathParam("environmentId") String environmentId,
             @PathParam("domain") String domain,
-            @PathParam("policy") String policy,
+            @PathParam("factor") String factor,
             @ApiParam(name = "identity", required = true) @Valid @NotNull UpdateFactor updateFactor,
             @Suspended final AsyncResponse response) {
         final User authenticatedUser = getAuthenticatedUser();
@@ -113,7 +113,7 @@ public class FactorResource extends AbstractResource {
         checkAnyPermission(organizationId, environmentId, domain, Permission.DOMAIN_FACTOR, Acl.UPDATE)
                 .andThen(domainService.findById(domain)
                         .switchIfEmpty(Maybe.error(new DomainNotFoundException(domain)))
-                        .flatMapSingle(__ -> factorService.update(domain, policy, updateFactor, authenticatedUser)))
+                        .flatMapSingle(__ -> factorService.update(domain, factor, updateFactor, authenticatedUser)))
                 .subscribe(response::resume, response::resume);
     }
 

--- a/gravitee-am-ui/src/app/services/organization.service.ts
+++ b/gravitee-am-ui/src/app/services/organization.service.ts
@@ -45,15 +45,15 @@ export class OrganizationService {
   }
 
   identities(expandIcon: boolean = false, expandDisplayName: boolean = false, expandLabels: boolean = false): Observable<any> {
-    return this.http.get<any>(this.organizationURL + '/plugins/identities' + this.computeIdentitiesParameters(false, expandIcon, expandDisplayName, expandLabels));
+    return this.http.get<any>(this.platformURL + '/plugins/identities' + this.computeIdentitiesParameters(false, expandIcon, expandDisplayName, expandLabels));
   }
 
   socialIdentities(expandIcon: boolean = false, expandDisplayName: boolean = false, expandLabels: boolean = false): Observable<any> {
-    return this.http.get<any>(this.organizationURL + '/plugins/identities' + this.computeIdentitiesParameters(true, expandIcon, expandDisplayName, expandLabels));
+    return this.http.get<any>(this.platformURL + '/plugins/identities' + this.computeIdentitiesParameters(true, expandIcon, expandDisplayName, expandLabels));
   }
 
   identitySchema(id): Observable<any> {
-    return this.http.get<any>(this.organizationURL + '/plugins/identities/' + id + '/schema');
+    return this.http.get<any>(this.platformURL + '/plugins/identities/' + id + '/schema');
   }
 
   identityProviders(): Observable<any> {
@@ -82,23 +82,23 @@ export class OrganizationService {
   }
 
   certificates(): Observable<any> {
-    return this.http.get<any>(this.organizationURL + '/plugins/certificates');
+    return this.http.get<any>(this.platformURL + '/plugins/certificates');
   }
 
   certificateSchema(id): Observable<any> {
-    return this.http.get<any>(this.organizationURL + '/plugins/certificates/' + id + '/schema');
+    return this.http.get<any>(this.platformURL + '/plugins/certificates/' + id + '/schema');
   }
 
   extensionGrants(): Observable<any> {
-    return this.http.get<any>(this.organizationURL + '/plugins/extensionGrants');
+    return this.http.get<any>(this.platformURL + '/plugins/extensionGrants');
   }
 
   extensionGrantSchema(id): Observable<any> {
-    return this.http.get<any>(this.organizationURL + '/plugins/extensionGrants/' + id + '/schema');
+    return this.http.get<any>(this.platformURL + '/plugins/extensionGrants/' + id + '/schema');
   }
 
   reporterSchema(id): Observable<any> {
-    return this.http.get<any>(this.organizationURL + '/plugins/reporters/' + id + '/schema');
+    return this.http.get<any>(this.platformURL + '/plugins/reporters/' + id + '/schema');
   }
 
   audits(page, size, type?, status?, user?, from?, to?): Observable<any> {
@@ -120,7 +120,7 @@ export class OrganizationService {
   }
 
   policies(expandSchema = false, expandIcon = false): Observable<any> {
-    let url = `${this.organizationURL}/plugins/policies`;
+    let url = `${this.platformURL}/plugins/policies`;
     const expand = [];
     if (expandSchema) {
       expand.push('expand=schema');
@@ -135,12 +135,12 @@ export class OrganizationService {
   }
 
   policySchema(id): Observable<any> {
-    return this.http.get<any>(this.organizationURL + '/plugins/policies/' + id + '/schema');
+    return this.http.get<any>(this.platformURL + '/plugins/policies/' + id + '/schema');
   }
 
   policyDocumentation(id): Observable<any> {
     const headers = new HttpHeaders().set('Content-Type', 'text/plain; charset=utf-8');
-    return this.http.get<any>(this.organizationURL + '/plugins/policies/' + id + '/documentation', {
+    return this.http.get<any>(this.platformURL + '/plugins/policies/' + id + '/documentation', {
       headers,
       responseType: 'text' as 'json'
     });
@@ -319,11 +319,11 @@ export class OrganizationService {
   }
 
   factors(): Observable<any> {
-    return this.http.get<any>(this.organizationURL + '/plugins/factors');
+    return this.http.get<any>(this.platformURL + '/plugins/factors');
   }
 
   factorSchema(id): Observable<any> {
-    return this.http.get<any>(this.organizationURL + '/plugins/factors/' + id + '/schema');
+    return this.http.get<any>(this.platformURL + '/plugins/factors/' + id + '/schema');
   }
 
   flowSchema(): Observable<any> {


### PR DESCRIPTION
The OpenApi descriptor was invalid due to

* the plugins routes defined under organizations: plugins are not related to an organization but they are related to higher-level (platform).
They should be called from `/management/platform/plugins/**`
It breaks the validation of the OpenApi descriptor (swagger.json) because plugins routes were not using the `organizationId` path params therefore it was not added to the descriptor.

* the path param in `FactorResource`: `policy` was incorrect, `FactorsResource` defines `{factor}` in the path
