### PR TITLE
chore(repository): declare jaxb-api explicitly to avoid missing depen…

### DIFF
--- a/gravitee-am-repository/gravitee-am-repository-jdbc/pom.xml
+++ b/gravitee-am-repository/gravitee-am-repository-jdbc/pom.xml
@@ -54,6 +54,7 @@
         <skip-repositories-tests>true</skip-repositories-tests>
 
         <maven-dependency-plugin.version>2.10</maven-dependency-plugin.version>
+        <dozer-jaxb-runtime.version>2.4.0-b180830.0438</dozer-jaxb-runtime.version>
     </properties>
 
     <dependencies>
@@ -225,6 +226,12 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>${dozer-jaxb-runtime.version}</version>
         </dependency>
 
         <dependency>

--- a/gravitee-am-repository/gravitee-am-repository-mongodb/pom.xml
+++ b/gravitee-am-repository/gravitee-am-repository-mongodb/pom.xml
@@ -87,6 +87,7 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>mongodb</artifactId>
             <version>${test-container.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
…dencies when building with JDK8

  set scope test for testcontainer in mongo repository

Fixe gravitee-io/issues#4891