### PR TITLE
fix(webauthn): set up default public key credential for apple attestation

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/auth/webauthn/impl/attestation/AppleAttestation.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-core/src/main/java/io/gravitee/am/gateway/handler/vertx/auth/webauthn/impl/attestation/AppleAttestation.java
@@ -120,10 +120,17 @@ public class AppleAttestation implements Attestation {
                 throw new AttestationException("credCert public key does not equal authData public key");
             }
 
+            // https://w3c.github.io/webauthn/#sctn-apple-anonymous-attestation
+            // the spec doesn't list "alg" yet devices do send it in some cases.
+            // the "alg" is important to support metadata in the future if a device gets blacklisted.
+            final PublicKeyCredential alg = attStmt.containsKey("alg") ?
+                    PublicKeyCredential.valueOf(attStmt.getInteger("alg")) :
+                    null;
+
             // meta data check
             metadata.verifyMetadata(
                     authData.getAaguidString(),
-                    PublicKeyCredential.valueOf(attStmt.getInteger("alg")),
+                    alg,
                     certChain);
 
 


### PR DESCRIPTION
fixes gravitee-io/issues#4921