### PR TITLE
fix(vhost): set cookie path if vhost mode is enabled on slash request path

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/CookieHandler.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-common/src/main/java/io/gravitee/am/gateway/handler/common/vertx/web/handler/impl/CookieHandler.java
@@ -74,7 +74,9 @@ public class CookieHandler implements Handler<RoutingContext> {
         }
 
         // Rewrite the cookie path (depends on domain path and possible X-Forwarded-Prefix request header).
-        cookie.setPath(forwardedPath);
+        // if vhost mode is enabled with a '/' path, the context.get(CONTEXT_PATH) is empty
+        // we have to force '/' path for the cookie to work
+        cookie.setPath(forwardedPath.isEmpty() ? "/" : forwardedPath);
 
         // Make sure the cookie secure attribute is set as expected.
         cookie.setSecure(cookieSecure);


### PR DESCRIPTION
fixes gravitee-io/issues#4966