### PR TITLE
Cicd/prepare release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,8 @@ version: 2.1
 parameters:
   gio_action:
     type: enum
-    enum: [release, pr_build]
-    default: pr_build
+    enum: [release, publish_rpms, pull_requests]
+    default: pull_requests
   dry_run:
     type: boolean
     default: true
@@ -13,6 +13,22 @@ parameters:
     type: string
     default: "gravitee-dry-run"
     description: "Maven ID of the Maven profile to use for a dry run ?"
+  ee_id_provider_cas_version:
+    type: string
+    default: $ID_PROVIDER_CAS_VERSION
+    description: "For Gravitee AM Release : The semver version number of the CAS identity provider plugin to bundle with GRavitee AM Entreprise Edition"
+  ee_id_provider_kerberos_version:
+    type: string
+    default: $ID_PROVIDER_KERBEROS_VERSION
+    description: "For Gravitee AM Release : The semver version number of the Kerberos identity provider plugin to bundle with GRavitee AM Entreprise Edition"
+  ee_id_provider_saml_version:
+    type: string
+    default: $ID_PROVIDER_SAML_VERSION
+    description: "For Gravitee AM Release : The semver version number of the SAML2 identity provider plugin to bundle with GRavitee AM Entreprise Edition"
+  ee_gravitee_license_version:
+    type: string
+    default: $ID_PROVIDER_SAML_VERSION
+    description: "The semver version number of the Gravitee License to bundle with Gravitee AM Entreprise Edition"
   secrethub_org:
     type: string
     default: "gravitee-lab"
@@ -21,43 +37,116 @@ parameters:
     type: string
     default: "cicd"
     description: "SecretHub Repo to use to fetch secrets ?"
+  graviteeio_version:
+    type: string
+    default: "cicd"
+    description: "Release version number to use to publish the Docker nightly images ?"
 
 orbs:
   gravitee: gravitee-io/gravitee@dev:1.0.4
+  secrethub: secrethub/cli@1.1.0
+
+# --- Jobs to perform all workflows
+# jobs:
+
 
 workflows:
   version: 2.1
+  # -- typically this workflow is executed on pull requests events for Community Edition Gravitee Repositories
   pull_requests:
     when:
-      equal: [ pr_build, << pipeline.parameters.gio_action >> ]
+      and:
+        - equal: [ pull_requests, << pipeline.parameters.gio_action >> ]
     jobs:
-      - gravitee/pr-build:
+      - gravitee/d_pull_requests_secrets:
           context: cicd-orchestrator
+          name: pr_secrets_resolution
+      - gravitee/d_pull_requests_ce:
+          name: process_pull_request
+          requires:
+            - pr_secrets_resolution
+          # "What is the maven ID of the maven profile to use to build and deploy SNAPSHOTS to Prviate Artifactory ?"
+          maven_profile_id: 'gio-dev'
+          # nexus_snapshots_url: 'https://oss.sonatype.org/content/repositories/snapshots'
+          # nexus_snapshots_server_id: 'sonatype-nexus-snapshots'
+          # container_gun_image_org: 'circleci'
+          # container_gun_image_name: 'openjdk'
+          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          container_size: 'xlarge'
+          filters:
+            branches:
+              ignore:
+                - master
+                # - /^[0-999].[0-999].x/ # Ignore support branches, because they are checked with noightly ? Would make sense...
+
+
+
   release:
-    # see https://circleci.com/docs/2.0/configuration-reference/#logic-statement-examples
     when:
       and:
         - equal: [ release, << pipeline.parameters.gio_action >> ]
-        - not: << pipeline.parameters.dry_run >>
+        - not : << pipeline.parameters.dry_run >>
     jobs:
-      # return to simple definition :
-      - gravitee/release:
+      - gravitee/d_am_release_secrets:
           context: cicd-orchestrator
+          name: 'am_release_secrets'
+      - gravitee/d_am_release:
+          requires:
+            - am_release_secrets
           dry_run: << pipeline.parameters.dry_run >>
-          secrethub_org: << pipeline.parameters.secrethub_org >>
-          secrethub_repo: << pipeline.parameters.secrethub_repo >>
-          maven_profile_id: << pipeline.parameters.maven_profile_id >>
+          maven_profile_id: 'gio-release'
+          # ee_id_provider_cas_version: << pipeline.parameters.ee_id_provider_cas_version >>
+          # ee_id_provider_kerberos_version: << pipeline.parameters.ee_id_provider_kerberos_version >>
+          ee_id_provider_saml_version: << pipeline.parameters.ee_id_provider_saml_version >>
+          ee_gravitee_license_version: << pipeline.parameters.ee_gravitee_license_version >>
+
   release_dry_run:
-    # see https://circleci.com/docs/2.0/configuration-reference/#logic-statement-examples
     when:
       and:
         - equal: [ release, << pipeline.parameters.gio_action >> ]
         - << pipeline.parameters.dry_run >>
     jobs:
-      # return to simple definition :
-      - gravitee/release:
+      - gravitee/d_am_release_secrets:
           context: cicd-orchestrator
+          name: 'am_release_secrets'
+      - gravitee/d_am_release:
+          requires:
+            - am_release_secrets
           dry_run: << pipeline.parameters.dry_run >>
-          secrethub_org: << pipeline.parameters.secrethub_org >>
-          secrethub_repo: << pipeline.parameters.secrethub_repo >>
-          maven_profile_id: << pipeline.parameters.maven_profile_id >>
+          maven_profile_id: 'gravitee-dry-run'
+          # ee_id_provider_cas_version: << pipeline.parameters.ee_id_provider_cas_version >>
+          # ee_id_provider_kerberos_version: << pipeline.parameters.ee_id_provider_kerberos_version >>
+          ee_id_provider_saml_version: << pipeline.parameters.ee_id_provider_saml_version >>
+          ee_gravitee_license_version: << pipeline.parameters.ee_gravitee_license_version >>
+
+
+
+  docker_nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+                - /^[0-999].[0-999].x/
+                - cicd/circleci-release
+    jobs:
+      - gravitee/d_am_nightly_secrets:
+          context: cicd-orchestrator
+          name: nightly_secrets_resolution
+      - gravitee/d_am_nightly:
+          name: docker_nightly
+          requires:
+            - nightly_secrets_resolution
+          container_size: 'xlarge'
+#
+  publish_rpms:
+    when:
+      equal: [ publish_rpms, << pipeline.parameters.gio_action >> ]
+    jobs:
+      - gravitee/publish_am_rpms:
+          context: cicd-orchestrator
+          secrethub_org: graviteeio
+          secrethub_repo: cicd
+          gio_release_version: << pipeline.parameters.graviteeio_version >>

--- a/gravitee-am-ui/pom.xml
+++ b/gravitee-am-ui/pom.xml
@@ -51,6 +51,8 @@
             <exclude>LICENSE.txt</exclude>
             <exclude>node/**</exclude>
             <exclude>src/libraries/**</exclude>
+            <exclude>dist/**</exclude>
+            <exclude>node_modules/**</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,8 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>19</version>
+        <!-- <version>19</version> -->
+        <version>19.2.1</version>
     </parent>
 
     <groupId>io.gravitee.am</groupId>
@@ -337,4 +338,19 @@
             <artifactId>mockito-core</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+      <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.8</version>
+            <configuration>
+                <additionalOptions>-Xdoclint:none</additionalOptions>
+                <source>8</source>
+            </configuration>
+
+        </plugin>
+      </plugins>
+    </build>
 </project>


### PR DESCRIPTION
This PR:
* prepares the `.circleci/config.yml` for the next 3.5.x release
* will bring small change to the `pom.xml` :  
  * upgrade `gravitee-parent` version
  * and one maven plugin configuration in `<build>`  section

* Release Dry run has been successful : https://app.circleci.com/pipelines/github/gravitee-io/graviteeio-access-management/1416/workflows/630d0e6b-1ada-4fe0-b612-2a9b17dc8839/jobs/1491
* automation of Zip Bundles is ready, for both ce and ee : 
  * the ce part is quite sure (relied on the script given by @tcompiegne 
  * the ee part has to be validated, here is how the ee zip is built : 
    * same zip as gravitee am full
    * but add an empty license folder
    * and add in plufgins folder of agteway and api all the ee plugins listed in https://download.gravitee.io/#graviteeio-ee/am/plugins/. (so CAS Kerberos and SAML)
    * see for all details of the structure of each zip : https://app.circleci.com/pipelines/github/gravitee-io/graviteeio-access-management/1416/workflows/630d0e6b-1ada-4fe0-b612-2a9b17dc8839/jobs/1491
 
at the end of the release, the zips will already be on download.gravite.io (no other process to launch)


**before merging:**
* I will rebase on `3.5.x`
* I will launch again the dry run
 

misc: 
* I had to add the `dist` and `node_modules` folders to maven license plugin configuration: 
  * because of https://app.circleci.com/pipelines/github/gravitee-io/graviteeio-access-management/1429/workflows/289012f1-2d9e-4476-83bb-01bd16e60162/jobs/1512
  * and here it is solved : https://app.circleci.com/pipelines/github/gravitee-io/graviteeio-access-management/1433/workflows/233cdd4f-2201-4543-ad87-bdd5a7e8dea4/jobs/1520