### PR TITLE
New Cicd Migration : Circle CI config.yml and gravitee parent upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,8 @@ version: 2.1
 parameters:
   gio_action:
     type: enum
-    enum: [release, pr_build]
-    default: pr_build
+    enum: [release, publish_rpms, pull_requests]
+    default: pull_requests
   dry_run:
     type: boolean
     default: true
@@ -13,6 +13,22 @@ parameters:
     type: string
     default: "gravitee-dry-run"
     description: "Maven ID of the Maven profile to use for a dry run ?"
+  ee_id_provider_cas_version:
+    type: string
+    default: ''
+    description: "For Gravitee AM Release : The semver version number of the CAS identity provider plugin to bundle with GRavitee AM Entreprise Edition"
+  ee_id_provider_kerberos_version:
+    type: string
+    default: ''
+    description: "For Gravitee AM Release : The semver version number of the Kerberos identity provider plugin to bundle with GRavitee AM Entreprise Edition"
+  ee_id_provider_saml_version:
+    type: string
+    default: ''
+    description: "For Gravitee AM Release : The semver version number of the SAML2 identity provider plugin to bundle with GRavitee AM Entreprise Edition"
+  ee_gravitee_license_version:
+    type: string
+    default: ''
+    description: "The semver version number of the Gravitee License to bundle with Gravitee AM Entreprise Edition"
   secrethub_org:
     type: string
     default: "gravitee-lab"
@@ -21,43 +37,116 @@ parameters:
     type: string
     default: "cicd"
     description: "SecretHub Repo to use to fetch secrets ?"
+  graviteeio_version:
+    type: string
+    default: "cicd"
+    description: "Release version number to use to publish the Docker nightly images ?"
 
 orbs:
   gravitee: gravitee-io/gravitee@dev:1.0.4
+  secrethub: secrethub/cli@1.1.0
+
+# --- Jobs to perform all workflows
+# jobs:
+
 
 workflows:
   version: 2.1
+  # -- typically this workflow is executed on pull requests events for Community Edition Gravitee Repositories
   pull_requests:
     when:
-      equal: [ pr_build, << pipeline.parameters.gio_action >> ]
+      and:
+        - equal: [ pull_requests, << pipeline.parameters.gio_action >> ]
     jobs:
-      - gravitee/pr-build:
+      - gravitee/d_pull_requests_secrets:
           context: cicd-orchestrator
+          name: pr_secrets_resolution
+      - gravitee/d_pull_requests_ce:
+          name: process_pull_request
+          requires:
+            - pr_secrets_resolution
+          # "What is the maven ID of the maven profile to use to build and deploy SNAPSHOTS to Prviate Artifactory ?"
+          maven_profile_id: 'gio-dev'
+          # nexus_snapshots_url: 'https://oss.sonatype.org/content/repositories/snapshots'
+          # nexus_snapshots_server_id: 'sonatype-nexus-snapshots'
+          # container_gun_image_org: 'circleci'
+          # container_gun_image_name: 'openjdk'
+          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          container_size: 'xlarge'
+          filters:
+            branches:
+              ignore:
+                - master
+                # - /^[0-999].[0-999].x/ # Ignore support branches, because they are checked with noightly ? Would make sense...
+
+
+
   release:
-    # see https://circleci.com/docs/2.0/configuration-reference/#logic-statement-examples
     when:
       and:
         - equal: [ release, << pipeline.parameters.gio_action >> ]
-        - not: << pipeline.parameters.dry_run >>
+        - not : << pipeline.parameters.dry_run >>
     jobs:
-      # return to simple definition :
-      - gravitee/release:
+      - gravitee/d_am_release_secrets:
           context: cicd-orchestrator
+          name: 'am_release_secrets'
+      - gravitee/d_am_release:
+          requires:
+            - am_release_secrets
           dry_run: << pipeline.parameters.dry_run >>
-          secrethub_org: << pipeline.parameters.secrethub_org >>
-          secrethub_repo: << pipeline.parameters.secrethub_repo >>
-          maven_profile_id: << pipeline.parameters.maven_profile_id >>
+          maven_profile_id: 'gio-release'
+          ee_id_provider_cas_version: << pipeline.parameters.ee_id_provider_cas_version >>
+          ee_id_provider_kerberos_version: << pipeline.parameters.ee_id_provider_kerberos_version >>
+          ee_id_provider_saml_version: << pipeline.parameters.ee_id_provider_saml_version >>
+          ee_gravitee_license_version: << pipeline.parameters.ee_gravitee_license_version >>
+
   release_dry_run:
-    # see https://circleci.com/docs/2.0/configuration-reference/#logic-statement-examples
     when:
       and:
         - equal: [ release, << pipeline.parameters.gio_action >> ]
         - << pipeline.parameters.dry_run >>
     jobs:
-      # return to simple definition :
-      - gravitee/release:
+      - gravitee/d_am_release_secrets:
           context: cicd-orchestrator
+          name: 'am_release_secrets'
+      - gravitee/d_am_release:
+          requires:
+            - am_release_secrets
           dry_run: << pipeline.parameters.dry_run >>
-          secrethub_org: << pipeline.parameters.secrethub_org >>
-          secrethub_repo: << pipeline.parameters.secrethub_repo >>
-          maven_profile_id: << pipeline.parameters.maven_profile_id >>
+          maven_profile_id: 'gravitee-dry-run'
+          ee_id_provider_cas_version: << pipeline.parameters.ee_id_provider_cas_version >>
+          ee_id_provider_kerberos_version: << pipeline.parameters.ee_id_provider_kerberos_version >>
+          ee_id_provider_saml_version: << pipeline.parameters.ee_id_provider_saml_version >>
+          ee_gravitee_license_version: << pipeline.parameters.ee_gravitee_license_version >>
+
+
+
+  docker_nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+                - /^[0-999].[0-999].x/
+                - cicd/circleci-release
+    jobs:
+      - gravitee/d_am_nightly_secrets:
+          context: cicd-orchestrator
+          name: nightly_secrets_resolution
+      - gravitee/d_am_nightly:
+          name: docker_nightly
+          requires:
+            - nightly_secrets_resolution
+          container_size: 'xlarge'
+#
+  publish_rpms:
+    when:
+      equal: [ publish_rpms, << pipeline.parameters.gio_action >> ]
+    jobs:
+      - gravitee/publish_am_rpms:
+          context: cicd-orchestrator
+          secrethub_org: graviteeio
+          secrethub_repo: cicd
+          gio_release_version: << pipeline.parameters.graviteeio_version >>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>19</version>
+        <version>19.2.1</version>
     </parent>
 
     <groupId>io.gravitee.am</groupId>


### PR DESCRIPTION
This PR brings, for `3.0.x` git branch:
* the same `.circleci/config.yml` as git branches on which releases have been done with new CICD ( `3.8.x`, `3.7.x`, `3.5.x`, etc....) : 
  * worth mentioning there: this  `.circleci/config.yml` allows "choosing if `kerberos` and `cas` identity providers are in the `Gravitee AM` `EE` release" -> If pipeline parameters `ee_id_provider_cas_version` and `ee_id_provider_kerberos_version` are empty strings (they are by default), then the `Gravitee AM` `EE` Release will not include the `kerberos` and `cas` identity providers
* plus gravitee parent upgrade to `19.2.1` : the gravitee parent version currently is `19`, and the `19.2.1` version is exactly the same as  `19` version, except there is only one additional maven profile, required by the new CICD