### PR TITLE
Gravitee AM UI : maven license plugin exclusions of 'dist/' and 'node_modules' directories

### DIFF
--- a/gravitee-am-ui/pom.xml
+++ b/gravitee-am-ui/pom.xml
@@ -50,6 +50,8 @@
             <exclude>LICENSE.txt</exclude>
             <exclude>node/**</exclude>
             <exclude>src/libraries/**</exclude>
+            <exclude>dist/**</exclude>
+            <exclude>node_modules/**</exclude>
           </excludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
added required maven license plugin exclusions of 'dist/' and 'node_modules' directories : 
* otherwise pull_requests Circleci workflow fails (forgot to add that with https://github.com/gravitee-io/graviteeio-access-management/pull/1125 )
* just like on `master` for example, see https://github.com/gravitee-io/graviteeio-access-management/blob/53fb94819ce5c6ce538c650d460d61e3b01204ab/gravitee-am-ui/pom.xml#L54


* fixes: https://app.circleci.com/pipelines/github/gravitee-io/graviteeio-access-management/1649/workflows/ee40dfe8-feda-4ada-ba0d-936c08414897/jobs/1883
* tested with : https://app.circleci.com/pipelines/github/gravitee-io/graviteeio-access-management/1650/workflows/0451d6d9-3853-4045-b1e7-08641696429c/jobs/1885