### PR TITLE
chore(deps): bump gravitee-cockpit-connectors-ws to 1.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <gravitee-policy-ipfiltering.version>1.5.0</gravitee-policy-ipfiltering.version>
         <gravitee-policy-request-validation.version>1.10.0</gravitee-policy-request-validation.version>
         <gravitee-license-node.version>1.1.0</gravitee-license-node.version>
-        <gravitee-cockpit-connectors.version>1.2.0</gravitee-cockpit-connectors.version>
+        <gravitee-cockpit-connectors.version>1.0.1</gravitee-cockpit-connectors.version>
         <gravitee-notifier-webhook.version>1.0.6</gravitee-notifier-webhook.version>
         <gravitee-notifier-email.version>1.2.8</gravitee-notifier-email.version>
         <gravitee-alert-api.version>1.7.0</gravitee-alert-api.version>


### PR DESCRIPTION
closes gravitee-io/issues#5478