### PR TITLE
chore(): be able to override max vertx http server configuration values

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/vertx/VertxHttpServerConfiguration.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/vertx/VertxHttpServerConfiguration.java
@@ -72,6 +72,18 @@ public class VertxHttpServerConfiguration implements InitializingBean {
     @Value("${http.tcpKeepAlive:true}")
     private boolean tcpKeepAlive;
 
+    @Value("${http.maxHeaderSize:8192}")
+    private int maxHeaderSize;
+
+    @Value("${http.maxChunkSize:8192}")
+    private int maxChunkSize;
+
+    @Value("${http.maxInitialLineLength:4096}")
+    private int maxInitialLineLength;
+
+    @Value("${http.maxFormAttributeSize:2048}")
+    private int maxFormAttributeSize;
+
     private ClientAuthMode clientAuth;
 
     public int getPort() {
@@ -192,6 +204,38 @@ public class VertxHttpServerConfiguration implements InitializingBean {
 
     public void setTlsProtocols(String tlsProtocols) {
         this.tlsProtocols = tlsProtocols;
+    }
+
+    public int getMaxHeaderSize() {
+        return maxHeaderSize;
+    }
+
+    public void setMaxHeaderSize(int maxHeaderSize) {
+        this.maxHeaderSize = maxHeaderSize;
+    }
+
+    public int getMaxChunkSize() {
+        return maxChunkSize;
+    }
+
+    public void setMaxChunkSize(int maxChunkSize) {
+        this.maxChunkSize = maxChunkSize;
+    }
+
+    public int getMaxInitialLineLength() {
+        return maxInitialLineLength;
+    }
+
+    public void setMaxInitialLineLength(int maxInitialLineLength) {
+        this.maxInitialLineLength = maxInitialLineLength;
+    }
+
+    public int getMaxFormAttributeSize() {
+        return maxFormAttributeSize;
+    }
+
+    public void setMaxFormAttributeSize(int maxFormAttributeSize) {
+        this.maxFormAttributeSize = maxFormAttributeSize;
     }
 
     @Override

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/vertx/VertxHttpServerFactory.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-container/src/main/java/io/gravitee/am/gateway/vertx/VertxHttpServerFactory.java
@@ -110,6 +110,10 @@ public class VertxHttpServerFactory implements FactoryBean<HttpServer> {
         options.setCompressionSupported(httpServerConfiguration.isCompressionSupported());
         options.setIdleTimeout(httpServerConfiguration.getIdleTimeout());
         options.setTcpKeepAlive(httpServerConfiguration.isTcpKeepAlive());
+        options.setMaxChunkSize(httpServerConfiguration.getMaxChunkSize());
+        options.setMaxHeaderSize(httpServerConfiguration.getMaxHeaderSize());
+        options.setMaxInitialLineLength(httpServerConfiguration.getMaxInitialLineLength());
+        options.setMaxFormAttributeSize(httpServerConfiguration.getMaxFormAttributeSize());
 
         return vertx.createHttpServer(options);
     }

--- a/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-am-gateway/gravitee-am-gateway-standalone/gravitee-am-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -34,6 +34,10 @@
 #  idleTimeout: 0
 #  tcpKeepAlive: true
 #  compressionSupported: false
+#  maxHeaderSize: 8192
+#  maxChunkSize: 8192
+#  maxInitialLineLength: 4096
+#  maxFormAttributeSize: 2048
 #  instances: 0
 #  secured: false
 #  alpn: false


### PR DESCRIPTION
fixes gravitee-io/issues#5506