### PR TITLE
return only the requested scopes when the enhance scopes with user permission option is active

### DIFF
--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/request/AbstractRequestResolver.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/main/java/io/gravitee/am/gateway/handler/oauth2/service/request/AbstractRequestResolver.java
@@ -100,8 +100,10 @@ public abstract class AbstractRequestResolver<R extends OAuth2Request> {
             return Single.error(new InvalidScopeException("Invalid scope(s): " + requestScopes.stream().collect(Collectors.joining(SCOPE_DELIMITER))));
         }
 
-        // set resolved scopes
-        request.setScopes(resolvedScopes);
+        // only put default values if there is no requested scopes
+        if (requestScopes == null || requestScopes.isEmpty()) {
+            request.setScopes(resolvedScopes);
+        }
 
         return Single.just(request);
     }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/request/AuthorizationRequestResolverTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/request/AuthorizationRequestResolverTest.java
@@ -172,10 +172,8 @@ public class AuthorizationRequestResolverTest {
         testObserver.assertNoErrors();
         
         // Request should have been enhanced with all of user's permissions, even though only one has been requested
-        List<String> expectedScopes = new ArrayList<>();
-        expectedScopes.add(scope);
-        expectedScopes.addAll(userScopes);
-        testObserver.assertValue(request -> request.getScopes().containsAll(expectedScopes) && request.getScopes().contains(scope) && request.getScopes().size() == 4);
+        List<String> expectedScopes = new ArrayList<>(authScopes);
+        testObserver.assertValue(request -> request.getScopes().containsAll(expectedScopes) && request.getScopes().contains(scope) && request.getScopes().size() == 2);
     }
     
     @Test
@@ -204,9 +202,8 @@ public class AuthorizationRequestResolverTest {
         
         List<String> expectedScopes = new ArrayList<>();
         expectedScopes.add(scope);
-        expectedScopes.addAll(userScopes);
-        
+
         // Request should have been enhanced with all of user's permissions, even though none of them has been requested
-        testObserver.assertValue(request -> request.getScopes().containsAll(expectedScopes) && request.getScopes().contains(scope) && request.getScopes().size() == 4);
+        testObserver.assertValue(request -> request.getScopes().containsAll(expectedScopes) && request.getScopes().contains(scope) && request.getScopes().size() == 1);
     }
 }

--- a/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/request/TokenRequestResolverTest.java
+++ b/gravitee-am-gateway/gravitee-am-gateway-handler/gravitee-am-gateway-handler-oidc/src/test/java/io/gravitee/am/gateway/handler/oauth2/service/request/TokenRequestResolverTest.java
@@ -103,10 +103,8 @@ public class TokenRequestResolverTest {
         testObserver.assertNoErrors();
         
         // Request should have been enhanced with all of user's permissions, even though only one has been requested
-        List<String> expectedScopes = new ArrayList<>();
-        expectedScopes.add(scope);
-        expectedScopes.addAll(userScopes);
-        testObserver.assertValue(request -> request.getScopes().containsAll(expectedScopes) && request.getScopes().contains(scope) && request.getScopes().size() == 4);
+        List<String> expectedScopes = new ArrayList<>(reqScopes);
+        testObserver.assertValue(request -> request.getScopes().containsAll(expectedScopes) && request.getScopes().contains(scope) && request.getScopes().size() == 2);
     }
     
     @Test
@@ -136,8 +134,7 @@ public class TokenRequestResolverTest {
         // Request should have been enhanced with all of user's permissions, even though none of them has been requested
         List<String> expectedScopes = new ArrayList<>();
         expectedScopes.add(scope);
-        expectedScopes.addAll(userScopes);
-        testObserver.assertValue(request -> request.getScopes().containsAll(expectedScopes) && request.getScopes().contains(scope) && request.getScopes().size() == 4);
+        testObserver.assertValue(request -> request.getScopes().containsAll(expectedScopes) && request.getScopes().contains(scope) && request.getScopes().size() == 1);
     }
 
     @Test


### PR DESCRIPTION
Fixes [gravitee-io/issues#3839](https://github.com/gravitee-io/issues/issues/3839)